### PR TITLE
Fix colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Gemfile.lock
 credentials.yml.enc
 master.key
+/spec/**/log/*.log
+/spec/**/storage/
+/spec/**/tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 ## main (unreleased)
 - Work in Progress
-
+- Fix exceptions caused by missing dependency for strings. ([#1](https://github.com/smridge/swagcov/pull/1))
 ## 0.2.0 (2021-04-20)
 - Add exit status to easily build a pass/fail into build pipeline
 

--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -7,5 +7,7 @@ if defined?(Rails)
   require "swagcov/coverage"
 end
 
+require "swagcov/core_ext/string"
+
 module Swagcov
 end

--- a/lib/swagcov/core_ext/string.rb
+++ b/lib/swagcov/core_ext/string.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class String
+  COLORS = {
+    red: 31,
+    green: 32,
+    yellow: 33,
+    blue: 34
+  }.freeze
+
+  # returns bold colors
+  COLORS.each_pair do |color, value|
+    define_method(color) do
+      "\e[1;#{value}m#{self}\e[0m"
+    end
+  end
+end


### PR DESCRIPTION
Fixes exceptions similar to `undefined method 'green' for "200":String`
- A different gem was installed on my machine allowing `"".green` to work. This was a classic "it works on my machine!". Thank you @jaydorsey for reporting!
- There is no need to add a dependency for such a method. Extended Ruby Core similar to [pry implementation](https://github.com/pry/pry/blob/master/lib/pry/helpers/text.rb)