### PR TITLE
Exclude Routes that live in the Rails Engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 ## main (unreleased)
 - Work in Progress
+- Fix: Exclude ActiveStorage and ActionMailer routes ([#3](https://github.com/smridge/swagcov/pull/3))
 
 ## 0.2.2 (2021-04-22)
 - Fix: Exclude Rails Internal Routes and Mounted Applications ([#2](https://github.com/smridge/swagcov/pull/2))

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -22,6 +22,11 @@ module Swagcov
 
         path = route.path.spec.to_s.sub(/\(\.:format\)$/, "")
 
+        # Exclude routes that are part of the rails gem that you would not write documentation for
+        # https://github.com/rails/rails/tree/main/activestorage/app/controllers/active_storage
+        # https://github.com/rails/rails/tree/main/actionmailbox/app/controllers/action_mailbox
+        next if path.include?("/active_storage/") || path.include?("/action_mailbox/")
+
         if ignore_path?(path)
           @ignored += 1
           @routes_ignored << { verb: route.verb, path: path, status: "ignored" }


### PR DESCRIPTION
This PR will exclude Routes for Controllers that live in the Rails Engines and not your application. Therefore, you would not be responsible for documenting. Addresses https://github.com/smridge/swagcov/pull/2#pullrequestreview-642380355 .

Routes that would be excluded (captured from running a normal `bundle exec rails routes`):
<img width="844" alt="routes" src="https://user-images.githubusercontent.com/44587895/115794474-0a6be180-a39c-11eb-9531-885136e45657.png">
