### PR TITLE
Extract dotfile management into a separate class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 ## main (unreleased)
 - Work in Progress
+- If a route path does not start with "^" match the entire path
+- Raise specific Swagcov::BadConfigurationError error if bad configuration
+- Route paths not matching _only_ rule are reported the same way as matching _ignore_
 
 ## 0.2.3 (2021-04-23)
 - Fix: Exclude ActiveStorage and ActionMailer routes ([#3](https://github.com/smridge/swagcov/pull/3))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 ## main (unreleased)
 - Work in Progress
 - If a route path does not start with "^" match the entire path
-- Raise specific Swagcov::BadConfigurationError error if bad configuration
-- Route paths not matching _only_ rule are reported the same way as matching _ignore_
+- Raise specific Swagcov::BadConfigurationError error if bad or missing configuration
 
 ## 0.2.3 (2021-04-23)
 - Fix: Exclude ActiveStorage and ActionMailer routes ([#3](https://github.com/smridge/swagcov/pull/3))

--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -4,6 +4,7 @@ require "swagcov/version"
 
 if defined?(Rails)
   require "swagcov/railtie"
+  require "swagcov/dotfile"
   require "swagcov/coverage"
 end
 

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -34,6 +34,8 @@ module Swagcov
           next
         end
 
+        next if dotfile.only_path_mismatch?(path)
+
         @total += 1
         regex = Regexp.new("#{path.gsub(%r{:[^/]+}, '\\{[^/]+\\}')}(\\.[^/]+)?$")
         matching_keys = docs_paths.keys.select { |k| regex.match?(k) }

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -9,6 +9,7 @@ module Swagcov
       @routes_not_covered = []
       @routes_covered = []
       @routes_ignored = []
+      @dotfile = Swagcov::Dotfile.new
     end
 
     def report
@@ -27,13 +28,11 @@ module Swagcov
         # https://github.com/rails/rails/tree/main/actionmailbox/app/controllers/action_mailbox
         next if path.include?("/active_storage/") || path.include?("/action_mailbox/")
 
-        if ignore_path?(path)
+        if dotfile.ignore_path?(path)
           @ignored += 1
           @routes_ignored << { verb: route.verb, path: path, status: "ignored" }
           next
         end
-
-        next if only_path_mismatch?(path)
 
         @total += 1
         regex = Regexp.new("#{path.gsub(%r{:[^/]+}, '\\{[^/]+\\}')}(\\.[^/]+)?$")
@@ -56,41 +55,15 @@ module Swagcov
       exit @total - @covered
     end
 
-    def dotfile
-      @dotfile ||= YAML.load_file(Rails.root.join(".swagcov.yml"))
-    end
-
     def docs_paths
-      @docs_paths ||= Dir.glob(dotfile["docs"]["paths"]).reduce({}) do |acc, docspath|
+      @docs_paths ||= Dir.glob(dotfile.doc_paths).reduce({}) do |acc, docspath|
         acc.merge(YAML.load_file(docspath)["paths"])
       end
     end
 
     private
 
-    def ignore_path? path
-      ignored_regex&.match?(path)
-    end
-
-    def ignored_regex
-      @ignored_regex ||= path_config_regex(dotfile.dig("routes", "paths", "ignore"))
-    end
-
-    def only_path_mismatch? path
-      only_regex && !only_regex.match?(path)
-    end
-
-    def only_regex
-      @only_regex ||= path_config_regex(dotfile.dig("routes", "paths", "only"))
-    end
-
-    def path_config_regex path_config
-      return unless path_config
-
-      config = path_config.map { |path| path.first == "^" ? path : "#{path}$" }
-
-      /#{config.join('|')}/
-    end
+    attr_reader :dotfile
 
     def routes_output routes, status_color
       routes.each do |route|

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Swagcov
+  class Dotfile
+    def initialize
+      @dotfile = YAML.load_file(Rails.root.join(".swagcov.yml"))
+    end
+
+    def ignore_path?(path)
+      true
+    end
+
+    private
+
+    attr_reader :dotfile
+  end
+end

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -7,7 +7,7 @@ module Swagcov
     end
 
     def ignore_path? path
-      ignored_regex&.match?(path)
+      ignored_regex&.match?(path) || (only_regex && !only_regex.match?(path))
     end
 
     private
@@ -16,6 +16,10 @@ module Swagcov
 
     def ignored_regex
       @ignored_regex ||= path_config_regex(dotfile.dig("routes", "paths", "ignore"))
+    end
+
+    def only_regex
+      @only_regex ||= path_config_regex(dotfile.dig("routes", "paths", "only"))
     end
 
     def path_config_regex path_config

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -6,7 +6,10 @@ module Swagcov
 
   class Dotfile
     def initialize
-      @dotfile = YAML.load_file(Rails.root.join(".swagcov.yml"))
+      pathname = Rails.root.join(".swagcov.yml")
+      raise BadConfigurationError, "Missing .swagcov.yml" unless pathname.exist?
+
+      @dotfile = YAML.load_file(pathname)
       raise BadConfigurationError, "Invalid .swagcov.yml" unless valid?
     end
 

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
 module Swagcov
+  class BadConfigurationError < RuntimeError
+  end
+
   class Dotfile
     def initialize
       @dotfile = YAML.load_file(Rails.root.join(".swagcov.yml"))
+      raise BadConfigurationError, "Invalid .swagcov.yml" unless valid?
     end
 
     def ignore_path? path
       ignored_regex&.match?(path) || (only_regex && !only_regex.match?(path))
+    end
+
+    def doc_paths
+      dotfile.dig("docs", "paths")
     end
 
     private
@@ -28,6 +36,10 @@ module Swagcov
       config = path_config.map { |path| path.first == "^" ? path : "^#{path}$" }
 
       /#{config.join('|')}/
+    end
+
+    def valid?
+      dotfile && doc_paths.present?
     end
   end
 end

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -39,7 +39,7 @@ module Swagcov
     end
 
     def valid?
-      dotfile && doc_paths.present?
+      dotfile && doc_paths
     end
   end
 end

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -14,7 +14,11 @@ module Swagcov
     end
 
     def ignore_path? path
-      ignored_regex&.match?(path) || (only_regex && !only_regex.match?(path))
+      ignored_regex&.match?(path)
+    end
+
+    def only_path_mismatch? path
+      only_regex && !only_regex.match?(path)
     end
 
     def doc_paths

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -6,12 +6,24 @@ module Swagcov
       @dotfile = YAML.load_file(Rails.root.join(".swagcov.yml"))
     end
 
-    def ignore_path?(path)
-      true
+    def ignore_path? path
+      ignored_regex&.match?(path)
     end
 
     private
 
     attr_reader :dotfile
+
+    def ignored_regex
+      @ignored_regex ||= path_config_regex(dotfile.dig("routes", "paths", "ignore"))
+    end
+
+    def path_config_regex path_config
+      return unless path_config
+
+      config = path_config.map { |path| path.first == "^" ? path : "^#{path}$" }
+
+      /#{config.join('|')}/
+    end
   end
 end

--- a/spec/fixtures/files/dotfile.yml
+++ b/spec/fixtures/files/dotfile.yml
@@ -1,0 +1,5 @@
+routes:
+  paths:
+    ignore:
+    - ^/v1
+    - /specific/path

--- a/spec/fixtures/files/dotfile.yml
+++ b/spec/fixtures/files/dotfile.yml
@@ -2,4 +2,9 @@ routes:
   paths:
     ignore:
     - ^/v1
-    - /specific/path
+    - /v3/specific
+    - /ignore/specific/path
+    only:
+    - ^/v2
+    - ^/v3
+    - /only/specific/path

--- a/spec/fixtures/files/dotfile.yml
+++ b/spec/fixtures/files/dotfile.yml
@@ -1,3 +1,8 @@
+docs:
+  paths:
+  - a/path
+  - b/path
+
 routes:
   paths:
     ignore:

--- a/spec/fixtures/files/missing_docs_dotfile.yml
+++ b/spec/fixtures/files/missing_docs_dotfile.yml
@@ -1,0 +1,4 @@
+routes:
+  paths:
+    only:
+    - a

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rails"
 require "swagcov"
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails"
+require "active_support/core_ext"
 require "swagcov"
 
 RSpec.configure do |config|

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Swagcov::Dotfile do
+  let(:rails_root) { instance_double(Pathname) }
+  let(:fixture_dotfile) { Pathname.new("spec/fixtures/files/dotfile.yml") }
+
+  before do
+    allow(Rails).to receive(:root).and_return(rails_root)
+    allow(rails_root).to receive(:join).and_return(fixture_dotfile)
+  end
+
+  it "loads yaml config from dotfile" do
+    expect(YAML).to receive(:load_file).with(fixture_dotfile)
+    described_class.new
+  end
+
+  describe "#ignore_path?" do
+    subject(:dotfile) { described_class.new }
+
+    describe "dotfile:routes:paths:ignore" do
+      it "returns true if path matches regexp" do
+        expect(dotfile.ignore_path?("/v1/think/about/pbt")).to be(true)
+      end
+    end
+  end
+end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -18,8 +18,24 @@ RSpec.describe Swagcov::Dotfile do
     subject(:dotfile) { described_class.new }
 
     describe "dotfile:routes:paths:ignore" do
-      it "returns true if path matches regexp" do
-        expect(dotfile.ignore_path?("/v1/think/about/pbt")).to be(true)
+      context "when specified as regexp" do
+        it "returns true if path matches regexp" do
+          expect(dotfile.ignore_path?("/v1/think/about/pbt")).to be(true)
+        end
+
+        it "returns false if path doesn't match ignored" do
+          expect(dotfile.ignore_path?("/v2/some")).to be(false)
+        end
+      end
+
+      context "when specified as string" do
+        it "returns true if path equals ignored string" do
+          expect(dotfile.ignore_path?("/specific/path")).to be(true)
+        end
+
+        it "returns false if path doesn't equal ignored string" do
+          expect(dotfile.ignore_path?("/specific/path/longer")).to be(false)
+        end
       end
     end
   end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -10,8 +10,24 @@ RSpec.describe Swagcov::Dotfile do
   end
 
   it "loads yaml config from dotfile" do
-    expect(YAML).to receive(:load_file).with(fixture_dotfile)
+    expect(YAML).to receive(:load_file).with(fixture_dotfile).and_call_original
     described_class.new
+  end
+
+  context "with empty dotfile" do
+    let(:fixture_dotfile) { Pathname.new("spec/fixtures/files/empty_dotfile.yml") }
+
+    it "raises error if file is empty" do
+      expect { described_class.new }.to raise_error(Swagcov::BadConfigurationError)
+    end
+  end
+
+  context "when misconfigured" do
+    let(:fixture_dotfile) { Pathname.new("spec/fixtures/files/missing_docs_dotfile.yml") }
+
+    it "raises error if doc paths are not specified in the dotfile" do
+      expect { described_class.new }.to raise_error(Swagcov::BadConfigurationError)
+    end
   end
 
   describe "#ignore_path?" do
@@ -66,5 +82,11 @@ RSpec.describe Swagcov::Dotfile do
         expect(dotfile.ignore_path?("/v3/specific")).to be(true)
       end
     end
+  end
+
+  describe "#doc_paths" do
+    subject(:doc_paths) { described_class.new.doc_paths }
+
+    it { is_expected.to contain_exactly("a/path", "b/path") }
   end
 end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Swagcov::Dotfile do
+  subject(:dotfile) { described_class.new }
+
   let(:rails_root) { instance_double(Pathname) }
   let(:fixture_dotfile) { Pathname.new("spec/fixtures/files/dotfile.yml") }
 
@@ -39,55 +41,45 @@ RSpec.describe Swagcov::Dotfile do
   end
 
   describe "#ignore_path?" do
-    subject(:dotfile) { described_class.new }
-
-    describe "dotfile:routes:paths:ignore" do
-      context "when specified as regexp" do
-        it "returns true if path matches regexp" do
-          expect(dotfile.ignore_path?("/v1/think/about/pbt")).to be(true)
-        end
-
-        it "returns false if path doesn't match ignored" do
-          expect(dotfile.ignore_path?("/v2/some")).to be(false)
-        end
+    context "when specified as regexp" do
+      it "returns true if path matches regexp" do
+        expect(dotfile.ignore_path?("/v1/think/about/pbt")).to be(true)
       end
 
-      context "when specified as string" do
-        it "returns true if path equals ignored string" do
-          expect(dotfile.ignore_path?("/ignore/specific/path")).to be(true)
-        end
-
-        it "returns false if path doesn't equal ignored string" do
-          expect(dotfile.ignore_path?("/v2/ignore/specific/path/longer")).to be(false)
-        end
+      it "returns false if path doesn't match ignored" do
+        expect(dotfile.ignore_path?("/v2/some")).to be(false)
       end
     end
 
-    describe "dotfile:routes:paths:only" do
-      context "when specified as regexp" do
-        it "returns false if path matches regexp" do
-          expect(dotfile.ignore_path?("/v2/something")).to be(false)
-        end
-
-        it "returns true if path doesn't match only" do
-          expect(dotfile.ignore_path?("/v4/some")).to be(true)
-        end
+    context "when specified as string" do
+      it "returns true if path equals ignored string" do
+        expect(dotfile.ignore_path?("/ignore/specific/path")).to be(true)
       end
 
-      context "when specified as string" do
-        it "returns false if path equals string" do
-          expect(dotfile.ignore_path?("/only/specific/path")).to be(false)
-        end
+      it "returns false if path doesn't equal ignored string" do
+        expect(dotfile.ignore_path?("/v2/ignore/specific/path/longer")).to be(false)
+      end
+    end
+  end
 
-        it "returns true if path doesn't equal string" do
-          expect(dotfile.ignore_path?("/only/specific/path/longer")).to be(true)
-        end
+  describe "#only_path_mismatch?" do
+    context "when specified as regexp" do
+      it "returns false if path matches regexp" do
+        expect(dotfile.only_path_mismatch?("/v2/something")).to be(false)
+      end
+
+      it "returns true if path doesn't match only" do
+        expect(dotfile.only_path_mismatch?("/v4/some")).to be(true)
       end
     end
 
-    describe "precedence" do
-      it "ignores first and applies only rules after" do
-        expect(dotfile.ignore_path?("/v3/specific")).to be(true)
+    context "when specified as string" do
+      it "returns false if path equals string" do
+        expect(dotfile.only_path_mismatch?("/only/specific/path")).to be(false)
+      end
+
+      it "returns true if path doesn't equal string" do
+        expect(dotfile.only_path_mismatch?("/only/specific/path/longer")).to be(true)
       end
     end
   end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -30,12 +30,40 @@ RSpec.describe Swagcov::Dotfile do
 
       context "when specified as string" do
         it "returns true if path equals ignored string" do
-          expect(dotfile.ignore_path?("/specific/path")).to be(true)
+          expect(dotfile.ignore_path?("/ignore/specific/path")).to be(true)
         end
 
         it "returns false if path doesn't equal ignored string" do
-          expect(dotfile.ignore_path?("/specific/path/longer")).to be(false)
+          expect(dotfile.ignore_path?("/v2/ignore/specific/path/longer")).to be(false)
         end
+      end
+    end
+
+    describe "dotfile:routes:paths:only" do
+      context "when specified as regexp" do
+        it "returns false if path matches regexp" do
+          expect(dotfile.ignore_path?("/v2/something")).to be(false)
+        end
+
+        it "returns true if path doesn't match only" do
+          expect(dotfile.ignore_path?("/v4/some")).to be(true)
+        end
+      end
+
+      context "when specified as string" do
+        it "returns false if path equals string" do
+          expect(dotfile.ignore_path?("/only/specific/path")).to be(false)
+        end
+
+        it "returns true if path doesn't equal string" do
+          expect(dotfile.ignore_path?("/only/specific/path/longer")).to be(true)
+        end
+      end
+    end
+
+    describe "precedence" do
+      it "ignores first and applies only rules after" do
+        expect(dotfile.ignore_path?("/v3/specific")).to be(true)
       end
     end
   end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe Swagcov::Dotfile do
     end
   end
 
+  context "when dotfile is missing" do
+    let(:fixture_dotfile) { Pathname.new("spec/fixtures/files/missing_file.yml") }
+
+    it "raises error if doc paths are not specified in the dotfile" do
+      expect { described_class.new }.to raise_error(Swagcov::BadConfigurationError)
+    end
+  end
+
   describe "#ignore_path?" do
     subject(:dotfile) { described_class.new }
 


### PR DESCRIPTION
I might have gotten a little bit carried away. My goal was to apply the «Single Responsibility Principle» while making code a little bit more testable. Having written the specs in isolation some of the things looked a bit inconsistent, so I had to tweak the behaviour (I think the regexp vs. string rule is still inconsistent).

This should also enable having a meaningful test for #4. Without a config reader it would be impossible to test the generator.

Also was a bit struggling with `docs_paths`, `doc_paths` and `docspath`.

Open for suggestions, feedback or other things.