### PR TITLE
Add test coverage for coverage.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   NewCops: enable
@@ -15,6 +16,12 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
 
 Style/Documentation:
   Enabled: false

--- a/spec/fixtures/files/swagcov.yml
+++ b/spec/fixtures/files/swagcov.yml
@@ -1,0 +1,3 @@
+docs:
+  paths:
+  - spec/fixtures/openapi/v1.yml

--- a/spec/fixtures/files/swagcov_with_ignore.yml
+++ b/spec/fixtures/files/swagcov_with_ignore.yml
@@ -1,0 +1,8 @@
+docs:
+  paths:
+  - spec/fixtures/openapi/v1.yml
+
+routes:
+  paths:
+    ignore:
+    - /articles/:id

--- a/spec/fixtures/files/swagcov_with_only.yml
+++ b/spec/fixtures/files/swagcov_with_only.yml
@@ -1,0 +1,8 @@
+docs:
+  paths:
+  - spec/fixtures/openapi/v1.yml
+
+routes:
+  paths:
+    only:
+    - /articles/:id

--- a/spec/fixtures/openapi/v1.yml
+++ b/spec/fixtures/openapi/v1.yml
@@ -1,0 +1,127 @@
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/articles":
+    get:
+      summary: list articles
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/article"
+    post:
+      summary: create article
+      tags:
+      - Articles
+      parameters: []
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                body:
+                  type: string
+  "/articles/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show article
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+    patch:
+      summary: update article
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+    put:
+      summary: update article
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+    delete:
+      summary: delete article
+      tags:
+      - Articles
+      responses:
+        '204':
+          description: deleted
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com
+components:
+  schemas:
+    article:
+      additionalProperties: false
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        attributes:
+          additionalProperties: false
+          type: object
+          properties:
+            title:
+              type: string
+            body:
+              type: string

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails"
+require "pry-byebug"
 require "active_support/core_ext"
 require "swagcov"
 

--- a/spec/swagcov/coverage_spec.rb
+++ b/spec/swagcov/coverage_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe Swagcov::Coverage do
+  subject(:init) { described_class.new }
+
+  let(:rails_root) { instance_double(Pathname) }
+  let(:irrelevant_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/anything") }
+  let(:articles_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)") }
+  let(:article_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles/:id(.:format)") }
+
+  let(:fake_routes) do
+    [
+      instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "GET", internal: true),
+      instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "", internal: nil),
+      instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "GET", internal: nil),
+      instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "POST", internal: nil),
+      instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "GET", internal: nil),
+      instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PATCH", internal: nil),
+      instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PUT", internal: nil),
+      instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "DELETE", internal: nil)
+    ]
+  end
+
+  before do
+    allow(Rails).to receive(:root).and_return(rails_root)
+    allow(Rails).to receive(:application) do
+      double.tap do |application|
+        allow(application).to receive(:routes) do
+          double.tap { |routes| allow(routes).to receive(:routes).and_return(fake_routes) }
+        end
+      end
+    end
+  end
+
+  describe "#collect_coverage" do
+    context "when internal route" do
+      before do
+        allow(rails_root).to receive(:join).and_return(Pathname.new("spec/fixtures/files/swagcov.yml"))
+        init.send(:collect_coverage)
+      end
+
+      let(:fake_routes) do
+        [
+          instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "GET", internal: true)
+        ]
+      end
+
+      it { expect(init.total).to eq(0) }
+      it { expect(init.covered).to eq(0) }
+      it { expect(init.ignored).to eq(0) }
+    end
+
+    context "when route without verb (mounted applications)" do
+      before do
+        allow(rails_root).to receive(:join).and_return(Pathname.new("spec/fixtures/files/swagcov.yml"))
+        init.send(:collect_coverage)
+      end
+
+      let(:fake_routes) do
+        [
+          instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "", internal: nil)
+        ]
+      end
+
+      it { expect(init.total).to eq(0) }
+      it { expect(init.covered).to eq(0) }
+      it { expect(init.ignored).to eq(0) }
+    end
+
+    context "with minimal configuration (no only or ignores)" do
+      before do
+        allow(rails_root).to receive(:join).and_return(Pathname.new("spec/fixtures/files/swagcov.yml"))
+        init.send(:collect_coverage)
+      end
+
+      it { expect(init.total).to eq(6) }
+      it { expect(init.covered).to eq(6) }
+      it { expect(init.ignored).to eq(0) }
+    end
+
+    context "with ignore routes configured" do
+      before do
+        allow(rails_root).to receive(:join).and_return(Pathname.new("spec/fixtures/files/swagcov_with_ignore.yml"))
+        init.send(:collect_coverage)
+      end
+
+      it { expect(init.total).to eq(2) }
+      it { expect(init.covered).to eq(2) }
+      it { expect(init.ignored).to eq(4) }
+    end
+
+    context "with only routes configured" do
+      before do
+        allow(rails_root).to receive(:join).and_return(Pathname.new("spec/fixtures/files/swagcov_with_only.yml"))
+        init.send(:collect_coverage)
+      end
+
+      it { expect(init.total).to eq(4) }
+      it { expect(init.covered).to eq(4) }
+      it { expect(init.ignored).to eq(0) }
+      it { expect(init.routes_not_covered).to eq([]) }
+      it { expect(init.routes_ignored).to eq([]) }
+
+      it "has array of covered routes" do
+        expect(init.routes_covered).to eq(
+          [
+            { verb: "GET", path: "/articles/:id", status: "200" },
+            { verb: "PATCH", path: "/articles/:id", status: "200" },
+            { verb: "PUT", path: "/articles/:id", status: "200" },
+            { verb: "DELETE", path: "/articles/:id", status: "204" }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/swagcov.gemspec
+++ b/swagcov.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
   spec.add_dependency "rails", ">= 5"
 
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"
+  spec.add_development_dependency "rubocop-rspec"
 end


### PR DESCRIPTION
Adds _some_ test coverage to main area of attraction with light refactoring.

Although there is healthy debate around testing private methods, `collect_coverage` is the main source of things. I wanted to easily test the counts etc. This is a bit difficult with `report` returning an `exit` code always.

## TODO
- Finish scenarios for `collect_coverage`