### PR TITLE
Fix matching route when swagger path partially exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 ## main (unreleased)
 - Work in Progress
+- Fix: Matching routes against swagger paths. Previously, partial paths could result in a match ([#12](https://github.com/smridge/swagcov/pull/12))
 
 ## 0.2.4 (2021-04-30)
 - Fix: If a route path does not start with "^" match the entire path ([#5](https://github.com/smridge/swagcov/pull/5))

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -45,7 +45,7 @@ module Swagcov
         next if dotfile.only_path_mismatch?(path)
 
         @total += 1
-        regex = Regexp.new("#{path.gsub(%r{:[^/]+}, '\\{[^/]+\\}')}(\\.[^/]+)?$")
+        regex = Regexp.new("^#{path.gsub(%r{:[^/]+}, '\\{[^/]+\\}')}(\\.[^/]+)?$")
         matching_keys = docs_paths.keys.select { |k| regex.match?(k) }
 
         if (doc = docs_paths.dig(matching_keys.first, route.verb.downcase))

--- a/spec/fixtures/files/swagcov_reference_v1.yml
+++ b/spec/fixtures/files/swagcov_reference_v1.yml
@@ -1,0 +1,3 @@
+docs:
+  paths:
+  - spec/fixtures/openapi/v1_endpoints.yml

--- a/spec/fixtures/openapi/v1_endpoints.yml
+++ b/spec/fixtures/openapi/v1_endpoints.yml
@@ -1,0 +1,127 @@
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/v1/articles":
+    get:
+      summary: list articles
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/article"
+    post:
+      summary: create article
+      tags:
+      - Articles
+      parameters: []
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                body:
+                  type: string
+  "/v1/articles/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show article
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+    patch:
+      summary: update article
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+    put:
+      summary: update article
+      tags:
+      - Articles
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/article"
+    delete:
+      summary: delete article
+      tags:
+      - Articles
+      responses:
+        '204':
+          description: deleted
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com
+components:
+  schemas:
+    article:
+      additionalProperties: false
+      type: object
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        attributes:
+          additionalProperties: false
+          type: object
+          properties:
+            title:
+              type: string
+            body:
+              type: string

--- a/spec/swagcov/coverage_spec.rb
+++ b/spec/swagcov/coverage_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Swagcov::Coverage do
 
   describe "#report" do
     let(:pathname) { Pathname.new("spec/fixtures/files/swagcov.yml") }
+
     # suppress output in specs
     before { allow($stdout).to receive(:puts) }
 
@@ -199,6 +200,28 @@ RSpec.describe Swagcov::Coverage do
           ]
         )
       end
+    end
+
+    context "when path name partially exists in swagger file" do
+      let(:pathname) { Pathname.new("spec/fixtures/files/swagcov_reference_v1.yml") }
+
+      let(:routes) do
+        [
+          instance_double(
+            ActionDispatch::Journey::Route,
+            path: instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)"),
+            verb: "GET",
+            internal: nil
+          )
+        ]
+      end
+
+      it { expect(init.total).to eq(1) }
+      it { expect(init.covered).to eq(0) }
+      it { expect(init.ignored).to eq(0) }
+      it { expect(init.routes_not_covered).to eq([{ verb: "GET", path: "/articles", status: "none" }]) }
+      it { expect(init.routes_ignored).to eq([]) }
+      it { expect(init.routes_covered).to eq([]) }
     end
   end
 end


### PR DESCRIPTION
This PR fixes when a swagger path can match a partial route name. For example, a swagger path is `/v1/articles` and your route is only `/articles`, the output will show "covered" when this is not the case.

I definitely need to cleanup the fixture files and the naming. The fixture yes merely copy and pasted from `spec/fixtures/openapi/v1.yml` with the path keys changed to `v1/articles`.  However, there is a test that will break if the start of line `^` regex is removed.