### PR TITLE
Replace select with grep

### DIFF
--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -46,7 +46,7 @@ module Swagcov
 
         @total += 1
         regex = Regexp.new("^#{path.gsub(%r{:[^/]+}, '\\{[^/]+\\}')}(\\.[^/]+)?$")
-        matching_keys = docs_paths.keys.select { |k| regex.match?(k) }
+        matching_keys = docs_paths.keys.grep(regex)
 
         if (doc = docs_paths.dig(matching_keys.first, route.verb.downcase))
           @covered += 1


### PR DESCRIPTION
- Replace `select` with `grep` for regex match.
  - This must be a new rubocop. Definitely learned something new and pretty clean!
  - **Bonus**: Addressing this rubocop resolved the `Metrics/CyclomaticComplexity` & `Metrics/PerceivedComplexity` for this method. 🎉 



