### PR TITLE
Add MFA requirement for RubyGem owner privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## main (unreleased)
 - Code Coverage: Add specs for Rails 5.2 ([#14](https://github.com/smridge/swagcov/pull/14))
 - Code Coverage: Add GitHub CodeQL ([#13](https://github.com/smridge/swagcov/pull/13))
+- Security: Require Multi-Factor Authentication for RubyGems privileged operations
 
 ## 0.2.5 (2021-09-14)
 - Fix: Matching routes against swagger paths. Previously, partial paths could result in a match ([#12](https://github.com/smridge/swagcov/pull/12))

--- a/swagcov.gemspec
+++ b/swagcov.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["lib/**/*", "LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
The Gem owners already have this enabled but this is a nice way to automate such 😃 