### PR TITLE
Add GitHub Actions for Specs

### DIFF
--- a/.github/workflows/base_specs.yml
+++ b/.github/workflows/base_specs.yml
@@ -1,0 +1,38 @@
+# This workflow runs units tests for the gem.
+# TODO: Get Rails Matrix to work
+
+name: Base Specs
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        # gemfile:
+        #   - rails_5_0
+        #   - rails_5_1
+        #   - rails_5_2
+        #   - rails_6
+        #   - rails_6_1
+        #   - rails_7
+
+    # env:
+    #   BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+    #   BUNDLE_PATH_RELATIVE_TO_CWD: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          rubygems: 'latest' # resolve warnings for older ruby versions
+          bundler-cache: true
+          cache-version: 1
+      - name: Run tests
+        run: bundle exec rspec spec --exclude-pattern spec/sandbox_**/**/*_spec.rb

--- a/.github/workflows/base_specs.yml
+++ b/.github/workflows/base_specs.yml
@@ -12,17 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
-        # gemfile:
-        #   - rails_5_0
-        #   - rails_5_1
-        #   - rails_5_2
-        #   - rails_6
-        #   - rails_6_1
-        #   - rails_7
-
-    # env:
-    #   BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
-    #   BUNDLE_PATH_RELATIVE_TO_CWD: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sandbox_5_2_specs.yml
+++ b/.github/workflows/sandbox_5_2_specs.yml
@@ -8,9 +8,6 @@ jobs:
   test:
     name: Rails 5.2 / Ruby 2.6
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
     services:
       postgres:
         image: postgres:11-alpine
@@ -24,17 +21,12 @@ jobs:
       RAILS_ENV: test
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
-    # defaults:
-    #   run:
-    #     working-directory: spec/sandbox_5_2
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          # ruby-version: ${{ matrix.ruby }}
           bundler: "Gemfile.lock"
           bundler-cache: true
           cache-version: 1

--- a/.github/workflows/sandbox_5_2_specs.yml
+++ b/.github/workflows/sandbox_5_2_specs.yml
@@ -1,0 +1,47 @@
+# This workflow runs end to end tests from a real Rails 5.2 application located in the spec/sandbox_5_2 directory.
+# TODO: Get Ruby Matrix to work
+
+name: "E2E Specs"
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Rails 5.2 / Ruby 2.6
+    runs-on: ubuntu-latest
+    # strategy:
+    #   matrix:
+    #     ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+
+    # defaults:
+    #   run:
+    #     working-directory: spec/sandbox_5_2
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          # ruby-version: ${{ matrix.ruby }}
+          bundler: "Gemfile.lock"
+          bundler-cache: true
+          cache-version: 1
+          working-directory: spec/sandbox_5_2
+      - name: Set up database schema
+        run: bundle exec rails db:schema:load
+        working-directory: spec/sandbox_5_2
+      - name: Run tests
+        run: bundle exec rspec spec
+        working-directory: spec/sandbox_5_2

--- a/.github/workflows/sandbox_6_0_specs.yml
+++ b/.github/workflows/sandbox_6_0_specs.yml
@@ -8,9 +8,6 @@ jobs:
   test:
     name: Rails 6.0 / Ruby 2.7
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
     services:
       postgres:
         image: postgres:11-alpine
@@ -24,17 +21,12 @@ jobs:
       RAILS_ENV: test
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
 
-    # defaults:
-    #   run:
-    #     working-directory: spec/sandbox_6_0
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          # ruby-version: ${{ matrix.ruby }}
           bundler: "Gemfile.lock"
           bundler-cache: true
           cache-version: 1

--- a/.github/workflows/sandbox_6_0_specs.yml
+++ b/.github/workflows/sandbox_6_0_specs.yml
@@ -1,0 +1,47 @@
+# This workflow runs end to end tests from a real Rails 6.0 application located in the spec/sandbox_6_0 directory.
+# TODO: Get Ruby Matrix to work
+
+name: "E2E Specs"
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Rails 6.0 / Ruby 2.7
+    runs-on: ubuntu-latest
+    # strategy:
+    #   matrix:
+    #     ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+
+    # defaults:
+    #   run:
+    #     working-directory: spec/sandbox_6_0
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          # ruby-version: ${{ matrix.ruby }}
+          bundler: "Gemfile.lock"
+          bundler-cache: true
+          cache-version: 1
+          working-directory: spec/sandbox_6_0
+      - name: Set up database schema
+        run: bundle exec rails db:schema:load
+        working-directory: spec/sandbox_6_0
+      - name: Run tests
+        run: bundle exec rspec spec
+        working-directory: spec/sandbox_6_0

--- a/spec/sandbox_5_2/.rspec
+++ b/spec/sandbox_5_2/.rspec
@@ -1,1 +1,3 @@
+--format documentation
+--color
 --require spec_helper

--- a/spec/sandbox_5_2/Gemfile
+++ b/spec/sandbox_5_2/Gemfile
@@ -13,8 +13,6 @@ gem "puma"
 
 group :development, :test do
   gem "database_cleaner"
-  gem "factory_bot_rails"
-  gem "faker"
   gem "pry"
   gem "pry-byebug"
   gem "rspec-rails"

--- a/spec/sandbox_5_2/Gemfile.lock
+++ b/spec/sandbox_5_2/Gemfile.lock
@@ -66,13 +66,6 @@ GEM
     database_cleaner-core (2.0.1)
     diff-lcs (1.5.0)
     erubi (1.10.0)
-    factory_bot (6.2.0)
-      activesupport (>= 5.0.0)
-    factory_bot_rails (6.2.0)
-      factory_bot (~> 6.2.0)
-      railties (>= 5.0.0)
-    faker (2.19.0)
-      i18n (>= 1.6, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -188,8 +181,6 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   database_cleaner
-  factory_bot_rails
-  faker
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/spec/sandbox_6_0/Gemfile.lock
+++ b/spec/sandbox_6_0/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     pg (1.3.2)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -189,6 +191,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)


### PR DESCRIPTION
Sets up a base for running specs. I was unable to get all the matrix combinations to work (the commented out areas). This PR is a first step to "make something work".

- Changes to `spec/sandbox_5_2/.rspec` were to help me verify what was running in GitHub Actions.
- Changes to `spec/sandbox_6_0/Gemfile.lock` were to get GitHub Actions to work.
- Removed gems in `sandbox_5_2` that are not being used.

Overall: 
- Runs the gem unit tests for all ruby versions this gem is meant to support
- Runs end to end specs for both Rails 5.2 and Rails 6.0 sandbox applications.

