### PR TITLE
Add Error Handling for malinformed yamls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 ## main (unreleased)
+
+### Enhancement
+  - Raise specific `Swagcov::BadConfigurationError` when malinformed config yaml file.
+
 ### Code Coverage
   - Add Sandbox Application and specs for Rails 5.1 ([#20](https://github.com/smridge/swagcov/pull/20))
   - Add specs for Rails 5.2 ([#14](https://github.com/smridge/swagcov/pull/14))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## main (unreleased)
 
 ### Enhancement
-  - Raise specific `Swagcov::BadConfigurationError` when malinformed config yaml file.
+  - Raise specific `Swagcov::BadConfigurationError` when malinformed yaml files ([#23](https://github.com/smridge/swagcov/pull/23))
 
 ### Code Coverage
   - Add Sandbox Application and specs for Rails 5.1 ([#20](https://github.com/smridge/swagcov/pull/20))

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -59,8 +59,14 @@ module Swagcov
 
     def docs_paths
       @docs_paths ||= Dir.glob(dotfile.doc_paths).reduce({}) do |acc, docspath|
-        acc.merge(YAML.load_file(docspath)["paths"])
+        acc.merge(load_yaml(docspath))
       end
+    end
+
+    def load_yaml docspath
+      YAML.load_file(docspath)["paths"]
+    rescue Psych::SyntaxError
+      raise BadConfigurationError, "Malinformed openapi file (#{docspath})"
     end
 
     def third_party_route? route, path

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -7,10 +7,9 @@ module Swagcov
   class Dotfile
     DEFAULT_CONFIG_FILE_NAME = ".swagcov.yml"
 
-    def initialize pathname: Rails.root.join(DEFAULT_CONFIG_FILE_NAME)
-      raise BadConfigurationError, "Missing config file (#{DEFAULT_CONFIG_FILE_NAME})" unless pathname.exist?
+    def initialize pathname: ::Rails.root.join(DEFAULT_CONFIG_FILE_NAME)
+      @dotfile = load_yaml(pathname)
 
-      @dotfile = YAML.load_file(pathname)
       raise BadConfigurationError, "Invalid config file (#{DEFAULT_CONFIG_FILE_NAME})" unless valid?
     end
 
@@ -29,6 +28,14 @@ module Swagcov
     private
 
     attr_reader :dotfile
+
+    def load_yaml pathname
+      raise BadConfigurationError, "Missing config file (#{DEFAULT_CONFIG_FILE_NAME})" unless pathname.exist?
+
+      YAML.load_file(pathname)
+    rescue Psych::SyntaxError
+      raise BadConfigurationError, "Malinformed config file (#{DEFAULT_CONFIG_FILE_NAME})"
+    end
 
     def ignored_regex
       @ignored_regex ||= path_config_regex(dotfile.dig("routes", "paths", "ignore"))

--- a/spec/fixtures/dotfiles/malinformed.yml
+++ b/spec/fixtures/dotfiles/malinformed.yml
@@ -1,0 +1,4 @@
+docs:
+  get a yaml linter!
+  paths:
+    - swagger/openapi.yaml

--- a/spec/fixtures/dotfiles/malinformed.yml
+++ b/spec/fixtures/dotfiles/malinformed.yml
@@ -1,4 +1,3 @@
 docs:
   get a yaml linter!
   paths:
-    - swagger/openapi.yaml

--- a/spec/fixtures/dotfiles/malinformed_openapi.yml
+++ b/spec/fixtures/dotfiles/malinformed_openapi.yml
@@ -1,0 +1,3 @@
+docs:
+  paths:
+    - spec/fixtures/openapi/malinformed.yml

--- a/spec/fixtures/openapi/malinformed.yml
+++ b/spec/fixtures/openapi/malinformed.yml
@@ -1,0 +1,2 @@
+openapi: 3.0.1
+get a yaml linter!

--- a/spec/swagcov/coverage_spec.rb
+++ b/spec/swagcov/coverage_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Swagcov::Coverage do
 
     let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
 
-    before do
-      allow($stdout).to receive(:puts) # suppress output in specs
-      result
-    end
+    # suppress output in specs
+    before { allow($stdout).to receive(:puts) }
 
     context "when internal route only" do
+      before { result }
+
       let(:routes) do
         [
           instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "GET", internal: true)
@@ -49,6 +49,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "when route without verb (mounted applications)" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
       let(:routes) do
         [
@@ -66,6 +68,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "with full documentation coverage and minimal configuration (no only or ignores)" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
 
       it { expect(init.total).to eq(6) }
@@ -91,6 +95,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "without full documentation coverage and minimal configuration" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths.yml") }
 
       it { expect(init.total).to eq(6) }
@@ -122,6 +128,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "with full documentation coverage and ignore routes configured" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_ignore.yml") }
 
       it { expect(init.total).to eq(2) }
@@ -153,6 +161,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "without full documentation coverage and ignore routes configured" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_ignore.yml") }
 
       it { expect(init.total).to eq(4) }
@@ -184,6 +194,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "with full documentation coverage and only routes configured" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_only.yml") }
 
       it { expect(init.total).to eq(4) }
@@ -207,6 +219,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "without full documentation coverage and only routes configured" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_only.yml") }
 
       it { expect(init.total).to eq(4) }
@@ -230,6 +244,8 @@ RSpec.describe Swagcov::Coverage do
     end
 
     context "when path name partially exists in swagger file" do
+      before { result }
+
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/v1.yml") }
 
       let(:routes) do
@@ -255,7 +271,7 @@ RSpec.describe Swagcov::Coverage do
     context "when maliformed openapi yaml" do
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/malinformed_openapi.yml") }
 
-      it { expect { init.send(:collect_coverage) }.to raise_error(Swagcov::BadConfigurationError) }
+      it { expect { result }.to raise_error(Swagcov::BadConfigurationError) }
     end
   end
 end

--- a/spec/swagcov/coverage_spec.rb
+++ b/spec/swagcov/coverage_spec.rb
@@ -251,5 +251,11 @@ RSpec.describe Swagcov::Coverage do
       it { expect(init.routes_covered).to eq([]) }
       it { expect(result).not_to eq(0) }
     end
+
+    context "when maliformed openapi yaml" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/malinformed_openapi.yml") }
+
+      it { expect { init.send(:collect_coverage) }.to raise_error(Swagcov::BadConfigurationError) }
+    end
   end
 end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Swagcov::Dotfile do
     end
   end
 
+  context "when malinformed dotfile" do
+    let(:fixture_dotfile) { Pathname.new("spec/fixtures/dotfiles/malinformed.yml") }
+
+    it "raises error if the yaml can not be loaded" do
+      expect { dotfile }.to raise_error(Swagcov::BadConfigurationError)
+    end
+  end
+
   context "when misconfigured" do
     let(:fixture_dotfile) { Pathname.new("spec/fixtures/dotfiles/missing_docs_dotfile.yml") }
 


### PR DESCRIPTION
Closes: https://github.com/smridge/swagcov/issues/10, thank you @jaydorsey for reporting!

- Added Error handling for a bad `.swagcov.yml` file
- Added Error handling for bad OpenAPI yamls

### Example for bad `.swagcov.yml`
<img width="919" alt="dotfile" src="https://user-images.githubusercontent.com/44587895/154895664-804d23e6-e5d8-4d55-b2da-d82f847d0618.png">

### Example for a bad `docs path` for an OpenAPI yaml
<img width="902" alt="openapi" src="https://user-images.githubusercontent.com/44587895/154895773-d6de6c30-5dfa-4e7a-a280-e6f22e61706b.png">

