### PR TITLE
Update SystemExit - move to rake task for easier testing

### DIFF
--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -23,7 +23,7 @@ module Swagcov
 
       final_output
 
-      exit @total - @covered
+      @total - @covered
     end
 
     private

--- a/lib/tasks/swagcove.rake
+++ b/lib/tasks/swagcove.rake
@@ -2,5 +2,5 @@
 
 desc "check documentation coverage for endpoints"
 task swagcov: :environment do
-  Swagcov::Coverage.new.report
+  exit Swagcov::Coverage.new.report
 end


### PR DESCRIPTION
Moved `exit` directly to rake task. This allows for much easier test writing. Previously, I was finding it difficult to test things having to either `rescue SystemExit` or test a private method directly. Now that end to end test coverage has been added, it's been much easier to see some of these things and make changes with more confidence.

At some point, I'd like to add a `Benchmark` to the rake task..but refactor first, then add. For example:
```ruby
cli = Swagcov::Coverage.new
result = 0

time = Benchmark.realtime { result = cli.report }
$stdout.puts "Finished in #{time} seconds"
exit result
```