### PR TITLE
Update Sandbox Applications after Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ bundle exec rspec spec --exclude-pattern spec/sandbox_**/**/*_spec.rb
 - Run: `rake release`
   - This command builds the gem, creates a tag and publishes to rubygems, see [bundler docs](https://bundler.io/guides/creating_gem.html#releasing-the-gem).
 
+- After all is good, `bundle update` all sandbox applications to reflect new swagcov version and open PR to ensure builds pass.
+
 ## TODO
 - Create Rails 7 / Ruby 3.1 Sandbox
 - Add autogeneration of ignore paths

--- a/spec/sandbox_5_1/Gemfile.lock
+++ b/spec/sandbox_5_1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    swagcov (0.2.5)
+    swagcov (0.3.0)
       rails (>= 5)
 
 GEM

--- a/spec/sandbox_5_2/Gemfile.lock
+++ b/spec/sandbox_5_2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    swagcov (0.2.5)
+    swagcov (0.3.0)
       rails (>= 5)
 
 GEM
@@ -85,12 +85,12 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.7.1)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
-    nokogiri (1.13.1)
-      mini_portile2 (~> 2.7.0)
+    nokogiri (1.13.2)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pg (1.3.2)
     pry (0.14.1)

--- a/spec/sandbox_6_0/Gemfile.lock
+++ b/spec/sandbox_6_0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    swagcov (0.2.5)
+    swagcov (0.3.0)
       rails (>= 5)
 
 GEM
@@ -100,9 +100,9 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.13.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.13.2-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.2)
     pry (0.13.1)

--- a/spec/sandbox_6_1/Gemfile.lock
+++ b/spec/sandbox_6_1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    swagcov (0.2.5)
+    swagcov (0.3.0)
       rails (>= 5)
 
 GEM
@@ -104,9 +104,9 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.13.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.13.2-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.2)
     pry (0.14.1)


### PR DESCRIPTION
After running `rake release`, a commit is pushed directly to `main`. The E2E tests fail due to the new version mismatch. This is a post step after releasing.