### PR TITLE
Refactor OpenAPI file processing

### DIFF
--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -6,6 +6,7 @@ if defined?(Rails)
   require "swagcov/railtie"
   require "swagcov/dotfile"
   require "swagcov/coverage"
+  require "swagcov/openapi_files"
 end
 
 require "swagcov/core_ext/string"

--- a/lib/swagcov/openapi_files.rb
+++ b/lib/swagcov/openapi_files.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Swagcov
+  class OpenapiFiles
+    def initialize filepaths:
+      @filepaths = filepaths
+      @openapi_paths = load_yamls
+    end
+
+    def find_response_keys path:, route_verb:
+      # replace :id with {id}
+      regex = Regexp.new("^#{path.gsub(%r{:[^/]+}, '\\{[^/]+\\}')}?$")
+
+      matching_paths_key = @openapi_paths.keys.grep(regex).first
+      matching_request_method_key = @openapi_paths.dig(matching_paths_key, route_verb.downcase)
+
+      matching_request_method_key["responses"].keys.map(&:to_s).sort if matching_request_method_key
+    end
+
+    private
+
+    def load_yamls
+      Dir.glob(@filepaths).reduce({}) do |hash, filepath|
+        hash.merge(load_yaml(filepath))
+      end
+    end
+
+    def load_yaml filepath
+      YAML.load_file(filepath)["paths"]
+    rescue Psych::SyntaxError
+      raise BadConfigurationError, "Malinformed openapi file (#{filepath})"
+    end
+  end
+end

--- a/spec/swagcov/openapi_files_spec.rb
+++ b/spec/swagcov/openapi_files_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Swagcov::OpenapiFiles do
+  subject(:openapi_files) { described_class.new(filepaths: fixture_doc_paths) }
+
+  context "when valid yamls" do
+    let(:fixture_doc_paths) do
+      [
+        Pathname.new("spec/fixtures/openapi/no_versions.yml")
+      ]
+    end
+
+    it "loads yaml" do
+      expect(YAML).to receive(:load_file).with("spec/fixtures/openapi/no_versions.yml").and_call_original
+      openapi_files
+    end
+  end
+
+  context "when malinformed yaml" do
+    let(:fixture_doc_paths) do
+      [
+        Pathname.new("spec/fixtures/openapi/no_versions.yml"),
+        Pathname.new("spec/fixtures/openapi/malinformed.yml")
+      ]
+    end
+
+    it { expect { openapi_files }.to raise_error(Swagcov::BadConfigurationError) }
+    it { expect { openapi_files }.to raise_error("Malinformed openapi file (spec/fixtures/openapi/malinformed.yml)") }
+  end
+
+  describe "#find_response_keys" do
+    let(:fixture_doc_paths) do
+      [
+        Pathname.new("spec/fixtures/openapi/no_versions.yml"),
+        Pathname.new("spec/fixtures/openapi/v1.yml")
+      ]
+    end
+
+    context "when matching route to openapi path" do
+      it { expect(openapi_files.find_response_keys(path: "/articles/:id", route_verb: "GET")).to eq(["200"]) }
+    end
+
+    context "without matching route to path" do
+      it { expect(openapi_files.find_response_keys(path: "/not_in_yaml/:id", route_verb: "GET")).to eq(nil) }
+    end
+  end
+end


### PR DESCRIPTION
After working on https://github.com/smridge/swagcov/pull/23, it seemed like a decent time to follow a similar pattern for the `Dotfile` processing. In addition, we should fail fast and check for an invalid openapi yaml first.