### PR TITLE
Fix ruby 3.4 support for older rails versions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,12 +46,6 @@ jobs:
             gemfile: gemfiles/rails_8_0 # ruby 3.2 minimum for rails 8.0
           - ruby-version: '3.1'
             gemfile: gemfiles/rails_8_0 # ruby 3.2 minimum for rails 8.0
-          - ruby-version: '3.4'
-            gemfile: gemfiles/rails_5_0
-          - ruby-version: '3.4'
-            gemfile: gemfiles/rails_5_1
-          - ruby-version: '3.4'
-            gemfile: gemfiles/rails_5_2
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,10 +52,6 @@ jobs:
             gemfile: gemfiles/rails_5_1
           - ruby-version: '3.4'
             gemfile: gemfiles/rails_5_2
-          - ruby-version: '3.4'
-            gemfile: gemfiles/rails_6_0
-          - ruby-version: '3.4'
-            gemfile: gemfiles/rails_6_1
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -56,8 +56,7 @@ jobs:
             gemfile: gemfiles/rails_6_0
           - ruby-version: '3.4'
             gemfile: gemfiles/rails_6_1
-          - ruby-version: '3.4'
-            gemfile: gemfiles/rails_7_0
+
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/gemfiles/rails_5_0
+++ b/gemfiles/rails_5_0
@@ -11,6 +11,10 @@ gemspec path: ".."
 
 gem "rails", "5.0.7.2"
 
+gem "bigdecimal" # Fix for ruby 3.4 (cannot load such file -- bigdecimal)
+gem "mutex_m" # Fix for ruby 3.4 (cannot load such file -- mutex_m)
+gem "base64" # Fix for ruby 3.4 (cannot load such file -- base64)
+
 # development dependencies
 gem "pry-byebug"
 gem "rspec"

--- a/gemfiles/rails_5_1
+++ b/gemfiles/rails_5_1
@@ -11,6 +11,10 @@ gemspec path: ".."
 
 gem "rails", "5.1.7"
 
+gem "bigdecimal" # Fix for ruby 3.4 (cannot load such file -- bigdecimal)
+gem "mutex_m" # Fix for ruby 3.4 (cannot load such file -- mutex_m)
+gem "base64" # Fix for ruby 3.4 (cannot load such file -- base64)
+
 # development dependencies
 gem "pry-byebug"
 gem "rspec"

--- a/gemfiles/rails_5_2
+++ b/gemfiles/rails_5_2
@@ -11,6 +11,9 @@ gemspec path: ".."
 
 gem "rails", "5.2.8.1"
 
+gem "bigdecimal" # Fix for ruby 3.4 (cannot load such file -- bigdecimal)
+gem "mutex_m" # Fix for ruby 3.4 (cannot load such file -- mutex_m)
+
 # development dependencies
 gem "pry-byebug"
 gem "rspec"

--- a/gemfiles/rails_6_0
+++ b/gemfiles/rails_6_0
@@ -10,6 +10,8 @@ end
 gemspec path: ".."
 
 gem "rails", "6.0.6.1"
+gem "bigdecimal" # Fix for ruby 3.4 (cannot load such file -- bigdecimal)
+gem "mutex_m" # Fix for ruby 3.4 (cannot load such file -- mutex_m)
 
 # development dependencies
 gem "pry-byebug"

--- a/gemfiles/rails_6_1
+++ b/gemfiles/rails_6_1
@@ -10,6 +10,8 @@ end
 gemspec path: ".."
 
 gem "rails", "6.1.7.10"
+gem "bigdecimal" # Fix for ruby 3.4 (cannot load such file -- bigdecimal)
+gem "mutex_m" # Fix for ruby 3.4 (cannot load such file -- mutex_m)
 
 # development dependencies
 gem "pry-byebug"

--- a/gemfiles/rails_7_0
+++ b/gemfiles/rails_7_0
@@ -10,6 +10,8 @@ end
 gemspec path: ".."
 
 gem "rails", "7.0.4.3"
+gem "bigdecimal" # Fix for ruby 3.4 (cannot load such file -- bigdecimal)
+gem "mutex_m" # Fix for ruby 3.4 (cannot load such file -- mutex_m)
 
 # development dependencies
 gem "pry-byebug"


### PR DESCRIPTION
- Added missing gems that were removed from the standard ruby library for older rails versions 