### PR TITLE
Replace Swagcov::VERSION with Swagcov::Version::STRING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 ## main (unreleased)
 ### Refactor
-- `BREAKING CHANGE`: `Swagcov::BadConfigurationError` is now `Swagcov::Errors::BadConfiguration` ([#74](https://github.com/smridge/swagcov/pull/74))
+- `BREAKING CHANGE`s:
+  - `Swagcov::BadConfigurationError` is now `Swagcov::Errors::BadConfiguration` ([#74](https://github.com/smridge/swagcov/pull/74))
+  - `Swagcov::VERSION` is now `Swagcov::Version::STRING` ([#77](https://github.com/smridge/swagcov/pull/77))
 - Improve path matching processing for `ignore` and `only` routes ([#65](https://github.com/smridge/swagcov/pull/65))
 
 ### Enhancement

--- a/lib/swagcov/version.rb
+++ b/lib/swagcov/version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module Swagcov
-  VERSION = "0.5.0"
+  module Version
+    STRING = "0.5.0"
+  end
 end

--- a/spec/swagcov/version_spec.rb
+++ b/spec/swagcov/version_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Swagcov::Version do
+  it { expect(described_class::STRING).not_to be_nil }
+end

--- a/spec/swagcov_spec.rb
+++ b/spec/swagcov_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe Swagcov do
-  it "has a version number" do
-    expect(described_class::VERSION).not_to be_nil
-  end
-end

--- a/swagcov.gemspec
+++ b/swagcov.gemspec
@@ -4,7 +4,7 @@ require_relative "lib/swagcov/version"
 
 Gem::Specification.new do |spec|
   spec.name     = "swagcov"
-  spec.version  = Swagcov::VERSION
+  spec.version  = Swagcov::Version::STRING
   spec.authors  = ["Sarah Ridge"]
   spec.email    = ["sarahmarie@hey.com"]
   spec.summary  = "OpenAPI documentation coverage for Rails Routes"


### PR DESCRIPTION
- Updated version lookup approach with more commonly used convention for gems