### PR TITLE
Refactor: separate coverage collection and output

### DIFF
--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -4,6 +4,7 @@ require "rails"
 require "active_support/core_ext"
 
 require "swagcov/core_ext/string"
+require "swagcov/formatter/console"
 require "swagcov/coverage"
 require "swagcov/dotfile"
 require "swagcov/errors"

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -2,7 +2,7 @@
 
 module Swagcov
   class Coverage
-    attr_reader :data
+    attr_reader :dotfile
 
     def initialize dotfile: ::Swagcov::Dotfile.new, routes: ::Rails.application.routes.routes
       @dotfile = dotfile
@@ -19,21 +19,10 @@ module Swagcov
     end
 
     def report
-      collect_coverage
-      routes_output(@data[:covered], "green")
-      routes_output(@data[:ignored], "yellow")
-      routes_output(@data[:uncovered], "red")
-
-      final_output
-
-      @data[:uncovered_count]
+      ::Swagcov::Formatter::Console.new(data: collect).run
     end
 
-    private
-
-    attr_reader :dotfile
-
-    def collect_coverage
+    def collect
       openapi_files = ::Swagcov::OpenapiFiles.new(filepaths: dotfile.docs_config)
       rails_version = ::Rails::VERSION::STRING
 
@@ -58,7 +47,11 @@ module Swagcov
           update_data(:uncovered, verb, path, "none")
         end
       end
+
+      @data
     end
+
+    private
 
     def third_party_route? route, path, rails_version
       # https://github.com/rails/rails/blob/48f3c3e201b57a4832314b2c957a3b303e89bfea/actionpack/lib/action_dispatch/routing/inspector.rb#L105-L107
@@ -85,60 +78,6 @@ module Swagcov
     def update_data key, verb, path, status
       @data[:"#{key}_count"] += 1
       @data[key] << { verb: verb, path: path, status: status }
-    end
-
-    def routes_output routes, status_color
-      routes.each do |route|
-        $stdout.puts(
-          format(
-            "%<verb>10s %<path>-#{min_width(:path) + 1}s %<status>s",
-            { verb: route[:verb], path: route[:path], status: route[:status].send(status_color) }
-          )
-        )
-      end
-    end
-
-    def min_width key
-      strings =
-        @data[:covered].map { |hash| hash[key] } +
-        @data[:ignored].map { |hash| hash[key] } +
-        @data[:uncovered].map { |hash| hash[key] }
-
-      strings.max_by(&:length).size
-    end
-
-    def final_output
-      $stdout.puts
-      $stdout.puts(
-        format(
-          "OpenAPI documentation coverage %<percentage>.2f%% (%<covered>d/%<total>d)",
-          {
-            percentage: 100.0 * @data[:covered_count] / @data[:total_count],
-            covered: @data[:covered_count],
-            total: @data[:total_count]
-          }
-        )
-      )
-
-      count_output
-    end
-
-    def count_output
-      {
-        ignored: "yellow",
-        total: "blue",
-        covered: "green",
-        uncovered: "red"
-      }.each do |key, color|
-        count = @data[:"#{key}_count"]
-
-        $stdout.puts(
-          format(
-            "%<status>s #{key} #{count == 1 ? 'endpoint' : 'endpoints'}",
-            { status: count.to_s.send(color) }
-          )
-        )
-      end
     end
   end
 end

--- a/lib/swagcov/formatter/console.rb
+++ b/lib/swagcov/formatter/console.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Swagcov
+  module Formatter
+    class Console
+      attr_reader :data
+
+      def initialize data: ::Swagcov::Coverage.new.collect
+        @data = data
+      end
+
+      def run
+        routes_output(data[:covered], "green")
+        routes_output(data[:ignored], "yellow")
+        routes_output(data[:uncovered], "red")
+        final_output
+
+        data[:uncovered_count]
+      end
+
+      private
+
+      def routes_output routes, status_color
+        routes.each do |route|
+          $stdout.puts(
+            format(
+              "%<verb>10s %<path>-#{min_width(:path) + 1}s %<status>s",
+              { verb: route[:verb], path: route[:path], status: route[:status].send(status_color) }
+            )
+          )
+        end
+      end
+
+      def min_width key
+        strings =
+          data[:covered].map { |hash| hash[key] } +
+          data[:ignored].map { |hash| hash[key] } +
+          data[:uncovered].map { |hash| hash[key] }
+
+        strings.max_by(&:length).size
+      end
+
+      def final_output
+        $stdout.puts
+        $stdout.puts(
+          format(
+            "OpenAPI documentation coverage %<percentage>.2f%% (%<covered>d/%<total>d)",
+            {
+              percentage: 100.0 * data[:covered_count] / data[:total_count],
+              covered: data[:covered_count],
+              total: data[:total_count]
+            }
+          )
+        )
+
+        count_output
+      end
+
+      def count_output
+        {
+          ignored: "yellow",
+          total: "blue",
+          covered: "green",
+          uncovered: "red"
+        }.each do |key, color|
+          count = data[:"#{key}_count"]
+
+          $stdout.puts(
+            format(
+              "%<status>s #{key} #{count == 1 ? 'endpoint' : 'endpoints'}",
+              { status: count.to_s.send(color) }
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/swagcov/coverage_spec.rb
+++ b/spec/swagcov/coverage_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe Swagcov::Coverage do
     end
   end
 
+  let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
+
+  before { allow($stdout).to receive(:puts) }
+
   describe "#report" do
     subject(:result) { init.report }
 
-    let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
-
     before do
-      allow($stdout).to receive(:puts)
-
       if Rails::VERSION::STRING < "5"
         dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: nil)
         routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
@@ -56,8 +56,6 @@ RSpec.describe Swagcov::Coverage do
           dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: 0)
           routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
         end
-
-        result
       end
 
       let(:routes) do
@@ -68,19 +66,10 @@ RSpec.describe Swagcov::Coverage do
         end
       end
 
-      it { expect(init.data[:total_count]).to eq(0) }
-      it { expect(init.data[:covered_count]).to eq(0) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(0) }
-      it { expect(init.data[:uncovered]).to eq([]) }
-      it { expect(init.data[:ignored]).to eq([]) }
-      it { expect(init.data[:covered]).to eq([]) }
       it { expect(result).to eq(0) }
     end
 
     context "when route without verb (mounted applications)" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
       let(:routes) do
         if Rails::VERSION::STRING > "5"
@@ -90,235 +79,52 @@ RSpec.describe Swagcov::Coverage do
         end
       end
 
-      it { expect(init.data[:total_count]).to eq(0) }
-      it { expect(init.data[:covered_count]).to eq(0) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(0) }
-      it { expect(init.data[:uncovered]).to eq([]) }
-      it { expect(init.data[:ignored]).to eq([]) }
-      it { expect(init.data[:covered]).to eq([]) }
       it { expect(result).to eq(0) }
     end
 
     context "with full documentation coverage and minimal configuration (no only or ignores)" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
-
-      it { expect(init.data[:total_count]).to eq(6) }
-      it { expect(init.data[:covered_count]).to eq(6) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(0) }
-      it { expect(init.data[:uncovered]).to eq([]) }
-      it { expect(init.data[:ignored]).to eq([]) }
-
-      it "has array of covered routes" do
-        expect(init.data[:covered]).to eq(
-          [
-            { verb: "GET", path: "/articles", status: "200" },
-            { verb: "POST", path: "/articles", status: "201" },
-            { verb: "GET", path: "/articles/:id", status: "200" },
-            { verb: "PATCH", path: "/articles/:id", status: "200" },
-            { verb: "PUT", path: "/articles/:id", status: "200" },
-            { verb: "DELETE", path: "/articles/:id", status: "204" }
-          ]
-        )
-      end
 
       it { expect(result).to eq(0) }
     end
 
     context "without full documentation coverage and minimal configuration" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths.yml") }
-
-      it { expect(init.data[:total_count]).to eq(6) }
-      it { expect(init.data[:covered_count]).to eq(2) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(4) }
-      it { expect(init.data[:ignored]).to eq([]) }
-
-      it "has array of uncovered routes" do
-        expect(init.data[:uncovered]).to eq(
-          [
-            { verb: "GET", path: "/articles/:id", status: "none" },
-            { verb: "PATCH", path: "/articles/:id", status: "none" },
-            { verb: "PUT", path: "/articles/:id", status: "none" },
-            { verb: "DELETE", path: "/articles/:id", status: "none" }
-          ]
-        )
-      end
-
-      it "has array of covered routes" do
-        expect(init.data[:covered]).to eq(
-          [
-            { verb: "GET", path: "/articles", status: "200" },
-            { verb: "POST", path: "/articles", status: "201" }
-          ]
-        )
-      end
 
       it { expect(result).not_to eq(0) }
     end
 
     context "with full documentation coverage and ignore routes configured" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_ignore.yml") }
-
-      it { expect(init.data[:total_count]).to eq(2) }
-      it { expect(init.data[:covered_count]).to eq(2) }
-      it { expect(init.data[:ignored_count]).to eq(4) }
-      it { expect(init.data[:uncovered_count]).to eq(0) }
-      it { expect(init.data[:uncovered]).to eq([]) }
-
-      it "has array of ignored routes" do
-        expect(init.data[:ignored]).to eq(
-          [
-            { verb: "GET", path: "/articles/:id", status: "ignored" },
-            { verb: "PATCH", path: "/articles/:id", status: "ignored" },
-            { verb: "PUT", path: "/articles/:id", status: "ignored" },
-            { verb: "DELETE", path: "/articles/:id", status: "ignored" }
-          ]
-        )
-      end
-
-      it "has array of covered routes" do
-        expect(init.data[:covered]).to eq(
-          [
-            { verb: "GET", path: "/articles", status: "200" },
-            { verb: "POST", path: "/articles", status: "201" }
-          ]
-        )
-      end
 
       it { expect(result).to eq(0) }
     end
 
     context "without full documentation coverage and ignore routes configured" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_ignore.yml") }
-
-      it { expect(init.data[:total_count]).to eq(4) }
-      it { expect(init.data[:covered_count]).to eq(0) }
-      it { expect(init.data[:ignored_count]).to eq(2) }
-      it { expect(init.data[:uncovered_count]).to eq(4) }
-      it { expect(init.data[:covered]).to eq([]) }
-
-      it "has array of uncovered routes" do
-        expect(init.data[:uncovered]).to eq(
-          [
-            { verb: "GET", path: "/articles/:id", status: "none" },
-            { verb: "PATCH", path: "/articles/:id", status: "none" },
-            { verb: "PUT", path: "/articles/:id", status: "none" },
-            { verb: "DELETE", path: "/articles/:id", status: "none" }
-          ]
-        )
-      end
-
-      it "has array of ignored routes" do
-        expect(init.data[:ignored]).to eq(
-          [
-            { verb: "GET", path: "/articles", status: "ignored" },
-            { verb: "POST", path: "/articles", status: "ignored" }
-          ]
-        )
-      end
 
       it { expect(result).not_to eq(0) }
     end
 
     context "with ignored routes configured with actions (verbs)" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/ignored_verbs.yml") }
-
-      it { expect(init.data[:total_count]).to eq(2) }
-      it { expect(init.data[:covered_count]).to eq(2) }
-      it { expect(init.data[:ignored_count]).to eq(4) }
-      it { expect(init.data[:uncovered_count]).to eq(0) }
-      it { expect(init.data[:uncovered]).to eq([]) }
-
-      it "has array of ignored routes" do
-        expect(init.data[:ignored]).to eq(
-          [
-            { verb: "GET", path: "/articles", status: "ignored" },
-            { verb: "POST", path: "/articles", status: "ignored" },
-            { verb: "PUT", path: "/articles/:id", status: "ignored" },
-            { verb: "DELETE", path: "/articles/:id", status: "ignored" }
-          ]
-        )
-      end
-
-      it "has array of covered routes" do
-        expect(init.data[:covered]).to eq(
-          [
-            { verb: "GET", path: "/articles/:id", status: "200" },
-            { verb: "PATCH", path: "/articles/:id", status: "200" }
-          ]
-        )
-      end
 
       it { expect(result).to eq(0) }
     end
 
     context "with full documentation coverage and only routes configured" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_only.yml") }
-
-      it { expect(init.data[:total_count]).to eq(4) }
-      it { expect(init.data[:covered_count]).to eq(4) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(0) }
-      it { expect(init.data[:uncovered]).to eq([]) }
-      it { expect(init.data[:ignored]).to eq([]) }
-
-      it "has array of covered routes" do
-        expect(init.data[:covered]).to eq(
-          [
-            { verb: "GET", path: "/articles/:id", status: "200" },
-            { verb: "PATCH", path: "/articles/:id", status: "200" },
-            { verb: "PUT", path: "/articles/:id", status: "200" },
-            { verb: "DELETE", path: "/articles/:id", status: "204" }
-          ]
-        )
-      end
 
       it { expect(result).to eq(0) }
     end
 
     context "without full documentation coverage and only routes configured" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_only.yml") }
-
-      it { expect(init.data[:total_count]).to eq(4) }
-      it { expect(init.data[:covered_count]).to eq(0) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(4) }
-      it { expect(init.data[:ignored]).to eq([]) }
-      it { expect(init.data[:covered]).to eq([]) }
-
-      it "has array of uncovered routes" do
-        expect(init.data[:uncovered]).to eq(
-          [
-            { verb: "GET", path: "/articles/:id", status: "none" },
-            { verb: "PATCH", path: "/articles/:id", status: "none" },
-            { verb: "PUT", path: "/articles/:id", status: "none" },
-            { verb: "DELETE", path: "/articles/:id", status: "none" }
-          ]
-        )
-      end
 
       it { expect(result).not_to eq(0) }
     end
 
     context "when path name partially exists in swagger file" do
-      before { result }
-
       let(:pathname) { Pathname.new("spec/fixtures/dotfiles/v1.yml") }
 
       let(:routes) do
@@ -342,14 +148,307 @@ RSpec.describe Swagcov::Coverage do
         end
       end
 
-      it { expect(init.data[:total_count]).to eq(1) }
-      it { expect(init.data[:covered_count]).to eq(0) }
-      it { expect(init.data[:ignored_count]).to eq(0) }
-      it { expect(init.data[:uncovered_count]).to eq(1) }
-      it { expect(init.data[:uncovered]).to eq([{ verb: "GET", path: "/articles", status: "none" }]) }
-      it { expect(init.data[:ignored]).to eq([]) }
-      it { expect(init.data[:covered]).to eq([]) }
       it { expect(result).not_to eq(0) }
+    end
+
+    context "when maliformed openapi yaml" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/malformed_openapi.yml") }
+
+      it { expect { result }.to raise_error(Swagcov::Errors::BadConfiguration) }
+    end
+  end
+
+  describe "#collect" do
+    subject(:result) { init.collect }
+
+    before do
+      if Rails::VERSION::STRING < "5"
+        dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: nil)
+        routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
+      end
+    end
+
+    context "when internal route only" do
+      before do
+        if Rails::VERSION::STRING < "5"
+          dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: 0)
+          routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
+        end
+      end
+
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "GET", internal: true)]
+        else
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: /^GET$/)]
+        end
+      end
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered: [],
+            ignored: [],
+            uncovered: [],
+            total_count: 0,
+            covered_count: 0,
+            ignored_count: 0,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
+
+    context "when route without verb (mounted applications)" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "", internal: nil)]
+        else
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "")]
+        end
+      end
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered: [],
+            ignored: [],
+            uncovered: [],
+            total_count: 0,
+            covered_count: 0,
+            ignored_count: 0,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
+
+    context "with full documentation coverage and minimal configuration (no only or ignores)" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered:
+              [
+                { verb: "GET", path: "/articles", status: "200" },
+                { verb: "POST", path: "/articles", status: "201" },
+                { verb: "GET", path: "/articles/:id", status: "200" },
+                { verb: "PATCH", path: "/articles/:id", status: "200" },
+                { verb: "PUT", path: "/articles/:id", status: "200" },
+                { verb: "DELETE", path: "/articles/:id", status: "204" }
+              ],
+            ignored: [],
+            uncovered: [],
+            total_count: 6,
+            covered_count: 6,
+            ignored_count: 0,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
+
+    context "without full documentation coverage and minimal configuration" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered:
+              [
+                { verb: "GET", path: "/articles", status: "200" },
+                { verb: "POST", path: "/articles", status: "201" }
+              ],
+            ignored: [],
+            uncovered:
+              [
+                { verb: "GET", path: "/articles/:id", status: "none" },
+                { verb: "PATCH", path: "/articles/:id", status: "none" },
+                { verb: "PUT", path: "/articles/:id", status: "none" },
+                { verb: "DELETE", path: "/articles/:id", status: "none" }
+              ],
+            total_count: 6,
+            covered_count: 2,
+            ignored_count: 0,
+            uncovered_count: 4
+          }
+        )
+      end
+    end
+
+    context "with full documentation coverage and ignore routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_ignore.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered:
+              [
+                { verb: "GET", path: "/articles", status: "200" },
+                { verb: "POST", path: "/articles", status: "201" }
+              ],
+            ignored:
+              [
+                { verb: "GET", path: "/articles/:id", status: "ignored" },
+                { verb: "PATCH", path: "/articles/:id", status: "ignored" },
+                { verb: "PUT", path: "/articles/:id", status: "ignored" },
+                { verb: "DELETE", path: "/articles/:id", status: "ignored" }
+              ],
+            uncovered: [],
+            total_count: 2,
+            covered_count: 2,
+            ignored_count: 4,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
+
+    context "without full documentation coverage and ignore routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_ignore.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered: [],
+            ignored:
+              [
+                { verb: "GET", path: "/articles", status: "ignored" },
+                { verb: "POST", path: "/articles", status: "ignored" }
+              ],
+            uncovered:
+              [
+                { verb: "GET", path: "/articles/:id", status: "none" },
+                { verb: "PATCH", path: "/articles/:id", status: "none" },
+                { verb: "PUT", path: "/articles/:id", status: "none" },
+                { verb: "DELETE", path: "/articles/:id", status: "none" }
+              ],
+            total_count: 4,
+            covered_count: 0,
+            ignored_count: 2,
+            uncovered_count: 4
+          }
+        )
+      end
+    end
+
+    context "with ignored routes configured with actions (verbs)" do
+      before { result }
+
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/ignored_verbs.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered:
+              [
+                { verb: "GET", path: "/articles/:id", status: "200" },
+                { verb: "PATCH", path: "/articles/:id", status: "200" }
+              ],
+            ignored:
+              [
+                { verb: "GET", path: "/articles", status: "ignored" },
+                { verb: "POST", path: "/articles", status: "ignored" },
+                { verb: "PUT", path: "/articles/:id", status: "ignored" },
+                { verb: "DELETE", path: "/articles/:id", status: "ignored" }
+              ],
+            uncovered: [],
+            total_count: 2,
+            covered_count: 2,
+            ignored_count: 4,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
+
+    context "with full documentation coverage and only routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_only.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered:
+              [
+                { verb: "GET", path: "/articles/:id", status: "200" },
+                { verb: "PATCH", path: "/articles/:id", status: "200" },
+                { verb: "PUT", path: "/articles/:id", status: "200" },
+                { verb: "DELETE", path: "/articles/:id", status: "204" }
+              ],
+            ignored: [],
+            uncovered: [],
+            total_count: 4,
+            covered_count: 4,
+            ignored_count: 0,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
+
+    context "without full documentation coverage and only routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_only.yml") }
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered: [],
+            ignored: [],
+            uncovered:
+              [
+                { verb: "GET", path: "/articles/:id", status: "none" },
+                { verb: "PATCH", path: "/articles/:id", status: "none" },
+                { verb: "PUT", path: "/articles/:id", status: "none" },
+                { verb: "DELETE", path: "/articles/:id", status: "none" }
+              ],
+            total_count: 4,
+            covered_count: 0,
+            ignored_count: 0,
+            uncovered_count: 4
+          }
+        )
+      end
+    end
+
+    context "when path name partially exists in swagger file" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/v1.yml") }
+
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [
+            instance_double(
+              ActionDispatch::Journey::Route,
+              path: instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)"),
+              verb: "GET",
+              internal: nil
+            )
+          ]
+        else
+          [
+            instance_double(
+              ActionDispatch::Journey::Route,
+              path: instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)"),
+              verb: /^GET$/
+            )
+          ]
+        end
+      end
+
+      it "collects route data" do
+        expect(result).to eq(
+          {
+            covered: [],
+            ignored: [],
+            uncovered: [{ verb: "GET", path: "/articles", status: "none" }],
+            total_count: 1,
+            covered_count: 0,
+            ignored_count: 0,
+            uncovered_count: 1
+          }
+        )
+      end
     end
 
     context "when maliformed openapi yaml" do

--- a/spec/swagcov/formatter/console_spec.rb
+++ b/spec/swagcov/formatter/console_spec.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require "action_dispatch/routing/inspector" # for rails < 5
+
+RSpec.describe Swagcov::Formatter::Console do
+  subject(:init) do
+    described_class.new(
+      data: Swagcov::Coverage.new(dotfile: Swagcov::Dotfile.new(pathname: pathname), routes: routes).collect
+    )
+  end
+
+  let(:irrelevant_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/anything") }
+  let(:articles_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)") }
+  let(:article_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles/:id(.:format)") }
+
+  let(:routes) do
+    if Rails::VERSION::STRING > "5"
+      [
+        instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "GET", internal: true),
+        instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "", internal: nil),
+        instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "GET", internal: nil),
+        instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "POST", internal: nil),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "GET", internal: nil),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PATCH", internal: nil),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PUT", internal: nil),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "DELETE", internal: nil)
+      ]
+    else
+      [
+        instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: ""),
+        instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: /^GET$/),
+        instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: /^POST$/),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^GET$/),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^PATCH$/),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^PUT$/),
+        instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^DELETE$/)
+      ]
+    end
+  end
+
+  before { allow($stdout).to receive(:puts) }
+
+  describe "#run" do
+    subject(:result) { init.run }
+
+    let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
+
+    before do
+      if Rails::VERSION::STRING < "5"
+        dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: nil)
+        routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
+      end
+    end
+
+    context "when internal route only" do
+      before do
+        if Rails::VERSION::STRING < "5"
+          dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: 0)
+          routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
+        end
+      end
+
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "GET", internal: true)]
+        else
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: /^GET$/)]
+        end
+      end
+
+      # rubocop:disable Layout/EmptyLinesAroundArguments
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+
+            OpenAPI documentation coverage NaN% (0/0)
+            #{0.to_s.yellow} ignored endpoints
+            #{0.to_s.blue} total endpoints
+            #{0.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).to eq(0) }
+    end
+
+    context "when route without verb (mounted applications)" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "", internal: nil)]
+        else
+          [instance_double(ActionDispatch::Journey::Route, path: irrelevant_path, verb: "")]
+        end
+      end
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+
+            OpenAPI documentation coverage NaN% (0/0)
+            #{0.to_s.yellow} ignored endpoints
+            #{0.to_s.blue} total endpoints
+            #{0.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+      # rubocop:enable Layout/EmptyLinesAroundArguments
+
+      it { expect(result).to eq(0) }
+    end
+
+    context "with full documentation coverage and minimal configuration (no only or ignores)" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles      #{200.to_s.green}
+                  POST /articles      #{201.to_s.green}
+                   GET /articles/:id  #{200.to_s.green}
+                 PATCH /articles/:id  #{200.to_s.green}
+                   PUT /articles/:id  #{200.to_s.green}
+                DELETE /articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (6/6)
+            #{0.to_s.yellow} ignored endpoints
+            #{6.to_s.blue} total endpoints
+            #{6.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).to eq(0) }
+    end
+
+    context "without full documentation coverage and minimal configuration" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles      #{200.to_s.green}
+                  POST /articles      #{201.to_s.green}
+                   GET /articles/:id  #{'none'.red}
+                 PATCH /articles/:id  #{'none'.red}
+                   PUT /articles/:id  #{'none'.red}
+                DELETE /articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 33.33% (2/6)
+            #{0.to_s.yellow} ignored endpoints
+            #{6.to_s.blue} total endpoints
+            #{2.to_s.green} covered endpoints
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).not_to eq(0) }
+    end
+
+    context "with full documentation coverage and ignore routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_ignore.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles      #{200.to_s.green}
+                  POST /articles      #{201.to_s.green}
+                   GET /articles/:id  #{'ignored'.yellow}
+                 PATCH /articles/:id  #{'ignored'.yellow}
+                   PUT /articles/:id  #{'ignored'.yellow}
+                DELETE /articles/:id  #{'ignored'.yellow}
+
+            OpenAPI documentation coverage 100.00% (2/2)
+            #{4.to_s.yellow} ignored endpoints
+            #{2.to_s.blue} total endpoints
+            #{2.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).to eq(0) }
+    end
+
+    context "without full documentation coverage and ignore routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_ignore.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles      #{'ignored'.yellow}
+                  POST /articles      #{'ignored'.yellow}
+                   GET /articles/:id  #{'none'.red}
+                 PATCH /articles/:id  #{'none'.red}
+                   PUT /articles/:id  #{'none'.red}
+                DELETE /articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 0.00% (0/4)
+            #{2.to_s.yellow} ignored endpoints
+            #{4.to_s.blue} total endpoints
+            #{0.to_s.green} covered endpoints
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).not_to eq(0) }
+    end
+
+    context "with ignored routes configured with actions (verbs)" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/ignored_verbs.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles/:id  #{'200'.green}
+                 PATCH /articles/:id  #{'200'.green}
+                   GET /articles      #{'ignored'.yellow}
+                  POST /articles      #{'ignored'.yellow}
+                   PUT /articles/:id  #{'ignored'.yellow}
+                DELETE /articles/:id  #{'ignored'.yellow}
+
+            OpenAPI documentation coverage 100.00% (2/2)
+            #{4.to_s.yellow} ignored endpoints
+            #{2.to_s.blue} total endpoints
+            #{2.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).to eq(0) }
+    end
+
+    context "with full documentation coverage and only routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/no_versions_with_only.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles/:id  #{'200'.green}
+                 PATCH /articles/:id  #{'200'.green}
+                   PUT /articles/:id  #{'200'.green}
+                DELETE /articles/:id  #{'204'.green}
+
+            OpenAPI documentation coverage 100.00% (4/4)
+            #{0.to_s.yellow} ignored endpoints
+            #{4.to_s.blue} total endpoints
+            #{4.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).to eq(0) }
+    end
+
+    context "without full documentation coverage and only routes configured" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/missing_paths_with_only.yml") }
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles/:id  #{'none'.red}
+                 PATCH /articles/:id  #{'none'.red}
+                   PUT /articles/:id  #{'none'.red}
+                DELETE /articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 0.00% (0/4)
+            #{0.to_s.yellow} ignored endpoints
+            #{4.to_s.blue} total endpoints
+            #{0.to_s.green} covered endpoints
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).not_to eq(0) }
+    end
+
+    context "when path name partially exists in swagger file" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/v1.yml") }
+
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [
+            instance_double(
+              ActionDispatch::Journey::Route,
+              path: instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)"),
+              verb: "GET",
+              internal: nil
+            )
+          ]
+        else
+          [
+            instance_double(
+              ActionDispatch::Journey::Route,
+              path: instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)"),
+              verb: /^GET$/
+            )
+          ]
+        end
+      end
+
+      it "outputs coverage" do
+        expect { result }.to output(
+          <<~MESSAGE
+                   GET /articles  #{'none'.red}
+
+            OpenAPI documentation coverage 0.00% (0/1)
+            #{0.to_s.yellow} ignored endpoints
+            #{1.to_s.blue} total endpoint
+            #{0.to_s.green} covered endpoints
+            #{1.to_s.red} uncovered endpoint
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(result).not_to eq(0) }
+    end
+
+    context "when maliformed openapi yaml" do
+      let(:pathname) { Pathname.new("spec/fixtures/dotfiles/malformed_openapi.yml") }
+
+      it { expect { result }.to raise_error(Swagcov::Errors::BadConfiguration) }
+    end
+  end
+end


### PR DESCRIPTION
- Separated coverage collection and output to make coverage collection reusable for upcoming enhancements such as:
  - different formatting options
  - autogenerating a `swagcov_todo.yml`