### PR TITLE
Create `.swagcov_todo` feature to automatically ignore existing uncovered routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ See OpenAPI documentation coverage report for Rails Routes.
 - See overview of different endpoints covered, missing and what you choose to ignore.
 - Add pass/fail to your build pipeline when missing Documentation Coverage.
 
-| Description | `rake task` | `rails console` |
+| `rake task` | `rails console` | Description |
 | :--- | :--- | :--- |
-| Install required config file | `rake swagcov:install` | `Swagcov::Command::GenerateDotfile.new.run` |
-| Check documentation coverage | `rake swagcov` | `Swagcov::Command::ReportCoverage.new.run` |
+| `rake swagcov` | `Swagcov::Command::ReportCoverage.new.run` | Check documentation coverage |
+| `rake swagcov:install` | `Swagcov::Command::GenerateDotfile.new.run` | Install required `.swagcov.yml` config file |
+|  | `Swagcov::Command::GenerateTodoFile.new.run` | Generate `.swagcov_todo.yml` |
 
 ## Ruby and Rails Version Support
 Versioning support from a test coverage perspective, see [tests.yml](/.github/workflows/tests.yml) for detail

--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -3,6 +3,7 @@
 require "rails"
 
 require "swagcov/command/generate_dotfile"
+require "swagcov/command/generate_todo_file"
 require "swagcov/command/report_coverage"
 require "swagcov/core_ext/string"
 require "swagcov/formatter/console"

--- a/lib/swagcov/command/generate_todo_file.rb
+++ b/lib/swagcov/command/generate_todo_file.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Swagcov
+  module Command
+    class GenerateTodoFile
+      STATUS_SUCCESS = 0
+
+      def initialize basename: ::Swagcov::Dotfile::TODO_CONFIG_FILE_NAME,
+                     data: ::Swagcov::Coverage.new(dotfile: ::Swagcov::Dotfile.new(skip_todo: true)).collect[:uncovered]
+        @dotfile = ::Swagcov.project_root.join(basename)
+        @data = data
+      end
+
+      def run
+        ::File.write(
+          @dotfile,
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            #{routes_yaml}
+          YAML
+        )
+
+        $stdout.puts "created #{@dotfile.basename} at #{@dotfile.dirname}"
+
+        STATUS_SUCCESS
+      end
+
+      private
+
+      def routes_yaml
+        return if routes.empty?
+
+        {
+          "routes" => {
+            "paths" => {
+              "ignore" => routes
+            }
+          }
+        }.to_yaml.strip
+      end
+
+      def routes
+        hash = {}
+
+        @data.each do |route|
+          hash[route[:path]] ? hash[route[:path]] << route[:verb] : hash[route[:path]] = [route[:verb]]
+        end
+
+        @routes ||= hash.map { |key, value| { key => value } }
+      end
+    end
+  end
+end

--- a/spec/fixtures/dotfiles/.todo.yml
+++ b/spec/fixtures/dotfiles/.todo.yml
@@ -1,0 +1,6 @@
+routes:
+  paths:
+    ignore:
+      - "/foo/:id":
+        - GET
+        - PATCH

--- a/spec/fixtures/dotfiles/.todo_misconfigured.yml
+++ b/spec/fixtures/dotfiles/.todo_misconfigured.yml
@@ -1,0 +1,4 @@
+# only routes.paths.ignore should be configured for a .swagcov_todo.yml file
+docs:
+  paths:
+    - wrong-file.yaml

--- a/spec/swagcov/command/generate_todo_file_spec.rb
+++ b/spec/swagcov/command/generate_todo_file_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require "action_dispatch/routing/inspector" if Rails::VERSION::STRING < "5"
+
+RSpec.describe Swagcov::Command::GenerateTodoFile do
+  subject(:init) { described_class.new(basename: basename, data: data) }
+
+  let(:basename) { ".swagcov_todo_test.yml" }
+
+  before { allow($stdout).to receive(:puts) } # suppress output in spec
+  after { FileUtils.rm_f(basename) }
+
+  describe "#run" do
+    context "when uncovered routes are empty" do
+      let(:data) { [] }
+
+      it "generates a todo configuration file" do
+        init.run
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { init.run }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(init.run).to eq(Swagcov::Command::GenerateTodoFile::STATUS_SUCCESS) }
+    end
+
+    context "with uncovered routes" do
+      let(:data) do
+        [
+          { verb: "GET", path: "/articles", status: "none" },
+          { verb: "PATCH", path: "/articles/:id", status: "none" },
+          { verb: "PUT", path: "/articles/:id", status: "none" }
+        ]
+      end
+
+      it "generates a todo configuration file" do
+        init.run
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/articles":
+                  - GET
+                - "/articles/:id":
+                  - PATCH
+                  - PUT
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { init.run }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(init.run).to eq(Swagcov::Command::GenerateTodoFile::STATUS_SUCCESS) }
+    end
+
+    context "with existing empty .swavcov_todo.yml file" do
+      let(:data) { [] }
+
+      before { init.run } # create existing
+
+      it "generates a todo configuration file" do
+        init.run
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { init.run }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(init.run).to eq(Swagcov::Command::GenerateTodoFile::STATUS_SUCCESS) }
+    end
+
+    context "with existing ignore config in .swagcov.yml and without full documentation coverage" do
+      let(:data) do
+        Swagcov::Coverage.new(
+          dotfile: Swagcov::Dotfile.new(
+            basename: "spec/fixtures/dotfiles/missing_paths_with_ignore.yml", todo_basename: basename, skip_todo: true
+          ), routes: routes
+        ).collect[:uncovered]
+      end
+
+      let(:articles_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)") }
+      let(:article_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles/:id(.:format)") }
+
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "GET", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "POST", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "GET", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PATCH", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PUT", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "DELETE", internal: nil)
+          ]
+        else
+          [
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: /^GET$/),
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: /^POST$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^GET$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^PATCH$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^PUT$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^DELETE$/)
+          ]
+        end
+      end
+
+      before do
+        if Rails::VERSION::STRING < "5"
+          dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: nil)
+          routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
+        end
+      end
+
+      it "generates a todo configuration file" do
+        init.run
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { init.run }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(init.run).to eq(Swagcov::Command::GenerateTodoFile::STATUS_SUCCESS) }
+    end
+
+    context "with existing ignore config in .swagcov_todo.yml" do
+      let(:data) do
+        Swagcov::Coverage.new(
+          dotfile: Swagcov::Dotfile.new(
+            basename: "spec/fixtures/dotfiles/missing_paths_with_ignore.yml", todo_basename: basename, skip_todo: true
+          ), routes: routes
+        ).collect[:uncovered]
+      end
+
+      let(:articles_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles(.:format)") }
+      let(:article_path) { instance_double(ActionDispatch::Journey::Path::Pattern, spec: "/articles/:id(.:format)") }
+
+      let(:routes) do
+        if Rails::VERSION::STRING > "5"
+          [
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "GET", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: "POST", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "GET", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PATCH", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "PUT", internal: nil),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: "DELETE", internal: nil)
+          ]
+        else
+          [
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: /^GET$/),
+            instance_double(ActionDispatch::Journey::Route, path: articles_path, verb: /^POST$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^GET$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^PATCH$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^PUT$/),
+            instance_double(ActionDispatch::Journey::Route, path: article_path, verb: /^DELETE$/)
+          ]
+        end
+      end
+
+      before do
+        if Rails::VERSION::STRING < "5"
+          dbl = instance_double(ActionDispatch::Routing::RouteWrapper, internal?: nil)
+          routes.each { |_route| allow(ActionDispatch::Routing::RouteWrapper).to receive(:new).and_return(dbl) }
+        end
+
+        described_class.new(
+          basename: basename,
+          data:
+            [
+              { verb: "GET", path: "/non-existing", status: "200" },
+              { verb: "GET", path: "/articles/:id", status: "200" },
+              { verb: "PATCH", path: "/articles/:id", status: "200" }
+            ]
+        ).run # create existing
+      end
+
+      it "regenerates a todo configuration file" do
+        init.run
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { init.run }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect(init.run).to eq(Swagcov::Command::GenerateTodoFile::STATUS_SUCCESS) }
+    end
+  end
+end

--- a/spec/swagcov/dotfile_spec.rb
+++ b/spec/swagcov/dotfile_spec.rb
@@ -112,6 +112,28 @@ RSpec.describe Swagcov::Dotfile do
     subject(:docs_config) { dotfile.ignored_config }
 
     it { is_expected.to contain_exactly("^/v1", "/v3/specific", "/ignore/specific/path") }
+
+    context "with misconfigured todo_file" do
+      subject(:dotfile) do
+        described_class.new(basename: fixture_dotfile, todo_basename: "spec/fixtures/dotfiles/.todo_misconfigured.yml")
+      end
+
+      it "only captures ignored routes" do
+        expect(dotfile.ignored_config).to contain_exactly("^/v1", "/v3/specific", "/ignore/specific/path")
+      end
+    end
+
+    context "with todo_file" do
+      subject(:dotfile) do
+        described_class.new(basename: fixture_dotfile, todo_basename: "spec/fixtures/dotfiles/.todo.yml")
+      end
+
+      it "merges results" do
+        expect(dotfile.ignored_config).to contain_exactly(
+          "^/v1", "/v3/specific", "/ignore/specific/path", { "/foo/:id" => %w[GET PATCH] }
+        )
+      end
+    end
   end
 
   describe "#only_config" do


### PR DESCRIPTION
- Added feature to automatically ignore existing uncovered routes in similar fashion to a `rubocop_todo.yml`. This enables forgiving existing uncovered documented endpoints and improve coverage _going forward_.
- For now, this can be ran in a `rails console` session with `Swagcov::Command::GenerateTodoFile.new.run`.
  - A followup PR will add a corresponding `rake task`