### PR TITLE
Add project_routes method

### DIFF
--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -24,4 +24,8 @@ module Swagcov
   def project_root
     ::Rails.root || ::Pathname.new(::FileUtils.pwd)
   end
+
+  def project_routes
+    ::Rails.application&.routes&.routes || []
+  end
 end

--- a/lib/swagcov/coverage.rb
+++ b/lib/swagcov/coverage.rb
@@ -4,7 +4,7 @@ module Swagcov
   class Coverage
     attr_reader :dotfile
 
-    def initialize dotfile: ::Swagcov::Dotfile.new, routes: ::Rails.application.routes.routes
+    def initialize dotfile: ::Swagcov::Dotfile.new, routes: ::Swagcov.project_routes
       @dotfile = dotfile
       @routes = routes
       @data = {

--- a/spec/swagcov/coverage_spec.rb
+++ b/spec/swagcov/coverage_spec.rb
@@ -337,5 +337,27 @@ RSpec.describe Swagcov::Coverage do
 
       it { expect { result }.to raise_error(Swagcov::Errors::BadConfiguration) }
     end
+
+    context "without rails routes" do
+      subject(:init) do
+        described_class.new(dotfile: Swagcov::Dotfile.new(basename: basename))
+      end
+
+      let(:basename) { "spec/fixtures/dotfiles/dotfile.yml" }
+
+      it "does not fail" do
+        expect(result).to eq(
+          {
+            covered: [],
+            ignored: [],
+            uncovered: [],
+            total_count: 0,
+            covered_count: 0,
+            ignored_count: 0,
+            uncovered_count: 0
+          }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
- Added `Swagcov.project_routes` method to prevent unexpected `NoMethodError` when commands are inadvertently ran outside of a rails application