### PR TITLE
Create executable as an alternative to the rake tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ RSpec/DescribeClass:
   Exclude:
     - '**/spec/tasks/**/*'
     - '**/spec/requests/**/*'
+    - '**/spec/exe/**/*'
 
 RSpec/ExampleLength:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -9,17 +9,27 @@
 ![CodeQL Build](https://github.com/smridge/swagcov/actions/workflows/codeql-analysis.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/smridge/swagcov/badge.svg?branch=main)](https://coveralls.io/github/smridge/swagcov?branch=main)
 
-See OpenAPI documentation coverage report for Rails Routes.
+OpenAPI documentation coverage report for Rails Routes.
 
 ## Usages
 - See overview of different endpoints covered, missing and what you choose to ignore.
-- Add pass/fail to your build pipeline when missing Documentation Coverage.
+- Add pass/fail to your build pipeline when missing documentation coverage.
 
-| `rake task` | `rails console` | Description |
-| :--- | :--- | :--- |
-| `rake swagcov` | `Swagcov::Command::ReportCoverage.new.run` | Check OpenAPI documentation coverage for Rails Route endpoints |
-| `rake swagcov:install` | `Swagcov::Command::GenerateDotfile.new.run` | Generate required `.swagcov.yml` config file |
-| `rake swagcov:generate_todo` | `Swagcov::Command::GenerateTodoFile.new.run` | Generate optional `.swagcov_todo.yml` config file |
+**Check OpenAPI documentation coverage for Rails Route endpoints**
+| `executable    ` | `rake task                 ` | `rails console                             ` |
+| :---             | :---                         | :---                                         |
+| `swagcov`        | `rake swagcov`               | `Swagcov::Command::ReportCoverage.new.run`   |
+
+**Generate required `.swagcov.yml` config file**
+| `executable    ` | `rake task                 ` | `rails console                             ` |
+| :---             | :---                         | :---                                         |
+| `swagcov --init` | `rake swagcov:install`       | `Swagcov::Command::GenerateDotfile.new.run`  |
+
+
+**Generate optional `.swagcov_todo.yml` config file**
+| `executable    ` | `rake task                 ` | `rails console                             ` |
+| :---             | :---                         | :---                                         |
+| `swagcov --todo` | `rake swagcov:generate_todo` | `Swagcov::Command::GenerateTodoFile.new.run` |
 
 ## Ruby and Rails Version Support
 Versioning support from a test coverage perspective, see [tests.yml](/.github/workflows/tests.yml) for detail

--- a/exe/swagcov
+++ b/exe/swagcov
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Experimental executable
+#
+# Booting rails approach should work for most applications
+# Rake task option as an alternative should always work as expected
+
+# Load logger before rails
+# Fix for booting rails 6.0-7.0 apps (uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger)
+require "logger"
+
+require "swagcov"
+
+RAILS_APP_PATH = File.expand_path("config/application", Dir.pwd)
+
+def boot_rails_application!
+  require RAILS_APP_PATH
+  Rails.application.initialize!
+rescue LoadError, NoMethodError
+  warn "Unable to load Rails application, try running `rake swagcov` instead"
+  exit Swagcov::STATUS_ERROR
+end
+
+boot_rails_application!
+
+Swagcov::Runner.new(args: ARGV).run

--- a/lib/swagcov.rb
+++ b/lib/swagcov.rb
@@ -11,7 +11,9 @@ require "swagcov/coverage"
 require "swagcov/dotfile"
 require "swagcov/errors"
 require "swagcov/openapi_files"
+require "swagcov/options"
 require "swagcov/railtie"
+require "swagcov/runner"
 require "swagcov/version"
 
 module Swagcov

--- a/lib/swagcov/dotfile.rb
+++ b/lib/swagcov/dotfile.rb
@@ -2,8 +2,8 @@
 
 module Swagcov
   class Dotfile
-    DEFAULT_CONFIG_FILE_NAME = ".swagcov.yml"
-    TODO_CONFIG_FILE_NAME = ".swagcov_todo.yml"
+    DEFAULT_CONFIG_FILE_NAME = ::ENV.fetch("SWAGCOV_DOTFILE", ".swagcov.yml")
+    TODO_CONFIG_FILE_NAME = ::ENV.fetch("SWAGCOV_TODOFILE", ".swagcov_todo.yml")
 
     def initialize basename: DEFAULT_CONFIG_FILE_NAME, todo_basename: TODO_CONFIG_FILE_NAME, skip_todo: false
       @dotfile = load_yaml(basename, required: true)

--- a/lib/swagcov/options.rb
+++ b/lib/swagcov/options.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "optparse"
+
+module Swagcov
+  class Options
+    def initialize args: ::ARGV
+      @args = args
+    end
+
+    def define
+      options = {}
+
+      ::OptionParser.new do |opts|
+        opts.banner = "Usage: swagcov [options]"
+
+        opts.on("-i", "--init", "Generate required .swagcov.yml config file") do |opt|
+          options[:init] = opt
+        end
+
+        opts.on("-t", "--todo", "Generate optional .swagcov_todo.yml config file") do |opt|
+          options[:todo] = opt
+        end
+      end.parse!(@args)
+
+      options
+    rescue ::OptionParser::InvalidOption => e
+      warn e.message
+      warn "For usage information, use --help"
+      exit ::Swagcov::STATUS_ERROR
+    end
+  end
+end

--- a/lib/swagcov/runner.rb
+++ b/lib/swagcov/runner.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Swagcov
+  class Runner
+    attr_reader :options
+
+    def initialize args: ::ARGV
+      @args = args
+      @options = ::Swagcov::Options.new(args: @args).define
+    end
+
+    def run
+      exit ::Swagcov::Command::GenerateDotfile.new.run if options[:init]
+      exit ::Swagcov::Command::GenerateTodoFile.new.run if options[:todo]
+      exit ::Swagcov::Command::ReportCoverage.new.run
+    end
+  end
+end

--- a/spec/sandbox_4_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_4_2/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_4_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_4_2/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end

--- a/spec/sandbox_5_0/Gemfile
+++ b/spec/sandbox_5_0/Gemfile
@@ -17,7 +17,6 @@ gem "puma", "~> 3.0"
 gem "multi_json"
 
 group :development, :test do
-  gem "pry-byebug"
   gem "rspec-rails"
   gem "rswag-specs", "2.11.0" # Fix FrozenError: can't modify frozen Hash & ignore deprecation outside of project scope
   gem "simplecov"

--- a/spec/sandbox_5_0/Gemfile.lock
+++ b/spec/sandbox_5_0/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     arel (7.1.4)
     builder (3.3.0)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     crass (1.0.6)
     diff-lcs (1.6.1)
@@ -96,12 +94,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
     public_suffix (4.0.7)
     puma (3.12.6)
     racc (1.8.1)
@@ -185,7 +177,6 @@ PLATFORMS
 
 DEPENDENCIES
   multi_json
-  pry-byebug
   puma (~> 3.0)
   rails (= 5.0.7.2)
   rspec-rails

--- a/spec/sandbox_5_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_5_0/spec/exe/swagcov_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_5_1/Gemfile
+++ b/spec/sandbox_5_1/Gemfile
@@ -17,7 +17,6 @@ gem "puma", "~> 3.7"
 gem "multi_json"
 
 group :development, :test do
-  gem "pry-byebug"
   gem "rspec-rails"
   gem "rswag-specs", "2.11.0" # Fix FrozenError: can't modify frozen Hash & ignore deprecation outside of project scope
   gem "simplecov"

--- a/spec/sandbox_5_1/Gemfile.lock
+++ b/spec/sandbox_5_1/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     arel (8.0.0)
     builder (3.3.0)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     crass (1.0.6)
     date (3.4.1)
@@ -93,12 +91,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
     public_suffix (5.1.1)
     puma (3.12.6)
     racc (1.8.1)
@@ -182,7 +174,6 @@ PLATFORMS
 
 DEPENDENCIES
   multi_json
-  pry-byebug
   puma (~> 3.7)
   rails (= 5.1.7)
   rspec-rails

--- a/spec/sandbox_5_1/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_5_1/spec/exe/swagcov_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_5_2/Gemfile
+++ b/spec/sandbox_5_2/Gemfile
@@ -14,7 +14,6 @@ gem "puma"
 gem "multi_json"
 
 group :development, :test do
-  gem "pry-byebug"
   gem "rspec-rails"
   gem "rswag-specs"
   gem "simplecov"

--- a/spec/sandbox_5_2/Gemfile.lock
+++ b/spec/sandbox_5_2/Gemfile.lock
@@ -56,8 +56,6 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     crass (1.0.6)
     date (3.4.1)
@@ -100,12 +98,6 @@ GEM
     nokogiri (1.15.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
     public_suffix (5.1.1)
     puma (6.6.0)
       nio4r (~> 2.0)
@@ -192,7 +184,6 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   multi_json
-  pry-byebug
   puma
   rails (= 5.2.8.1)
   rspec-rails

--- a/spec/sandbox_5_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_5_2/spec/exe/swagcov_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_6_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_6_0/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_6_1/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_6_1/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_7_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_7_0/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_7_1/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_7_1/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_7_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_7_2/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/sandbox_8_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_8_0/spec/exe/swagcov_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+describe "[executable] swagcov" do
+  context "without optional arguments" do
+    subject(:swagcov) { system %(swagcov) }
+
+    context "with minimal configuration and full documentation coverage" do
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                   GET /articles         #{200.to_s.green}
+                  POST /articles         #{201.to_s.green}
+                   GET /articles/:id     #{200.to_s.green}
+                 PATCH /articles/:id     #{200.to_s.green}
+                   PUT /articles/:id     #{200.to_s.green}
+                DELETE /articles/:id     #{204.to_s.green}
+                   GET /users            #{200.to_s.green}
+                  POST /users            #{201.to_s.green}
+                   GET /users/:id        #{200.to_s.green}
+                 PATCH /users/:id        #{200.to_s.green}
+                   PUT /users/:id        #{200.to_s.green}
+                DELETE /users/:id        #{204.to_s.green}
+                   GET /v1/articles      #{200.to_s.green}
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles/:id  #{200.to_s.green}
+                 PATCH /v1/articles/:id  #{200.to_s.green}
+                   PUT /v1/articles/:id  #{200.to_s.green}
+                DELETE /v1/articles/:id  #{204.to_s.green}
+                   GET /v2/articles      #{200.to_s.green}
+                  POST /v2/articles      #{201.to_s.green}
+                   GET /v2/articles/:id  #{200.to_s.green}
+                 PATCH /v2/articles/:id  #{200.to_s.green}
+                   PUT /v2/articles/:id  #{200.to_s.green}
+                DELETE /v2/articles/:id  #{204.to_s.green}
+
+            OpenAPI documentation coverage 100.00% (24/24)
+            #{0.to_s.yellow} ignored endpoints
+            #{24.to_s.blue} total endpoints
+            #{24.to_s.green} covered endpoints
+            #{0.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "with full configuration and partial documentation coverage" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "outputs coverage" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+                  POST /v1/articles      #{201.to_s.green}
+                   GET /v1/articles      #{'ignored'.yellow}
+                   GET /v2/articles/:id  #{'ignored'.yellow}
+                 PATCH /v2/articles/:id  #{'ignored'.yellow}
+                   PUT /v2/articles/:id  #{'ignored'.yellow}
+                DELETE /v2/articles/:id  #{'ignored'.yellow}
+                   GET /v1/articles/:id  #{'none'.red}
+                 PATCH /v1/articles/:id  #{'none'.red}
+                   PUT /v1/articles/:id  #{'none'.red}
+                DELETE /v1/articles/:id  #{'none'.red}
+
+            OpenAPI documentation coverage 20.00% (1/5)
+            #{5.to_s.yellow} ignored endpoints
+            #{5.to_s.blue} total endpoints
+            #{1.to_s.green} covered endpoint
+            #{4.to_s.red} uncovered endpoints
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without required configuration" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/no-dotfile.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "prints message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+          MESSAGE
+        ).to_stderr_from_any_process
+      end
+    end
+  end
+
+  context "with --help option" do
+    subject(:swagcov) { system %(swagcov --help) }
+
+    it "prints options" do
+      expect { swagcov }.to output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout_from_any_process
+    end
+  end
+
+  context "with --init option" do
+    subject(:swagcov) { system %(swagcov --init) }
+
+    context "when dotfile exists" do
+      it "does not overwrite existing file" do
+        swagcov
+
+        expect(File.read(Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME)).to eq(
+          <<~YAML
+            docs:
+              paths:
+                - swagger/openapi.yaml
+                - swagger/v2_openapi.json
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            #{Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "when dotfile does not exist" do
+      let(:basename) { ".swagcov_test.yml" }
+
+      before { ENV["SWAGCOV_DOTFILE"] = basename }
+
+      after do
+        ENV["SWAGCOV_DOTFILE"] = nil
+        FileUtils.rm_f(basename)
+      end
+
+      it "creates a minimum configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+
+  context "with --todo option" do
+    subject(:swagcov) { system %(swagcov --todo) }
+
+    let(:basename) { ".swagcov_test.yml" }
+
+    before { ENV["SWAGCOV_TODOFILE"] = basename }
+
+    after do
+      ENV["SWAGCOV_TODOFILE"] = nil
+      FileUtils.rm_f(basename)
+    end
+
+    context "with uncovered routes" do
+      before { ENV["SWAGCOV_DOTFILE"] = "spec/fixtures/dotfiles/only_and_ignore_config.yml" }
+      after { ENV["SWAGCOV_DOTFILE"] = nil }
+
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+            ---
+            routes:
+              paths:
+                ignore:
+                - "/v1/articles/:id":
+                  - GET
+                  - PATCH
+                  - PUT
+                  - DELETE
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+
+    context "without uncovered routes" do
+      it "generates a todo configuration file" do
+        swagcov
+
+        expect(File.read(basename)).to eq(
+          <<~YAML
+            # This configuration was auto generated
+            # The intent is to remove these route configurations as documentation is added
+
+          YAML
+        )
+      end
+
+      it "has message" do
+        expect { swagcov }.to output(
+          <<~MESSAGE
+            created #{basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/swagcov/options_spec.rb
+++ b/spec/swagcov/options_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Swagcov::Options do
+  subject(:init) do
+    described_class.new(args: args)
+  end
+
+  describe "#define" do
+    context "without options" do
+      let(:args) { [] }
+
+      it { expect(init.define).to eq({}) }
+    end
+
+    context "with invalid options" do
+      let(:args) { ["--foobar"] }
+
+      it "prints message" do
+        expect { init.define }.to raise_exception(SystemExit).and output(
+          <<~MESSAGE
+            invalid option: --foobar
+            For usage information, use --help
+          MESSAGE
+        ).to_stderr
+      end
+
+      it { expect { init.define }.to exit_with_code(2) }
+    end
+
+    context "with -h" do
+      let(:args) { ["-h"] }
+
+      it "prints options" do
+        expect { init.define }.to raise_exception(SystemExit).and output(
+          <<~MESSAGE
+            Usage: swagcov [options]
+                -i, --init                       Generate required .swagcov.yml config file
+                -t, --todo                       Generate optional .swagcov_todo.yml config file
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect { init.define }.to exit_with_code(0) }
+    end
+
+    context "with --help" do
+      let(:args) { ["--help"] }
+
+      it "prints options" do
+        expect { init.define }.to raise_exception(SystemExit).and output(
+          <<~MESSAGE
+            Usage: swagcov [options]
+                -i, --init                       Generate required .swagcov.yml config file
+                -t, --todo                       Generate optional .swagcov_todo.yml config file
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect { init.define }.to exit_with_code(0) }
+    end
+
+    context "with valid shorthand options" do
+      let(:args) { ["-i", "-t"] }
+
+      it { expect(init.define).to eq({ init: true, todo: true }) }
+      it { expect(described_class.new(args: ["-i"]).define).to eq({ init: true }) }
+      it { expect(described_class.new(args: ["-t"]).define).to eq({ todo: true }) }
+    end
+
+    context "with valid explicit options" do
+      let(:args) { ["--init", "--todo"] }
+
+      it { expect(init.define).to eq({ init: true, todo: true }) }
+      it { expect(described_class.new(args: ["--init"]).define).to eq({ init: true }) }
+      it { expect(described_class.new(args: ["--todo"]).define).to eq({ todo: true }) }
+    end
+  end
+end

--- a/spec/swagcov/runner_spec.rb
+++ b/spec/swagcov/runner_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+# require "action_dispatch/routing/inspector" if Rails::VERSION::STRING < "5"
+
+RSpec.describe Swagcov::Runner do
+  subject(:init) do
+    described_class.new(args: args)
+  end
+
+  context "with --help" do
+    let(:args) { ["--help"] }
+
+    it "prints options" do
+      expect { init.run }.to raise_exception(SystemExit).and output(
+        <<~MESSAGE
+          Usage: swagcov [options]
+              -i, --init                       Generate required .swagcov.yml config file
+              -t, --todo                       Generate optional .swagcov_todo.yml config file
+        MESSAGE
+      ).to_stdout
+    end
+
+    it { expect { init.run }.to exit_with_code(0) }
+    it { expect { described_class.new(args: ["-h"]).run }.to exit_with_code(0) }
+  end
+
+  context "with --init" do
+    let(:args) { ["--init"] }
+    let(:dotfile_basename) { ".swagcov_test.yml" }
+
+    before { stub_const("Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME", dotfile_basename) }
+    after { FileUtils.rm_f(dotfile_basename) }
+
+    context "when dotfile does not exist" do
+      it "creates a minimum configuration file" do
+        init.run
+      rescue SystemExit => _e
+        expect(File.read(dotfile_basename)).to eq(
+          <<~YAML
+            ## Required field:
+            # List your OpenAPI documentation file(s) (accepts json or yaml)
+            docs:
+              paths:
+                - swagger.yaml
+                - swagger.json
+
+            ## Optional fields:
+            # routes:
+            #   paths:
+            #     only:
+            #       - ^/v2 # only track v2 endpoints
+            #     ignore:
+            #       - /v2/users # do not track certain endpoints
+            #       - /v2/users/:id: # ignore only certain actions (verbs)
+            #         - GET
+          YAML
+        )
+      end
+
+      it "outputs message" do
+        expect { init.run }.to raise_exception(SystemExit).and output(
+          <<~MESSAGE
+            created #{dotfile_basename} at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect { init.run }.to exit_with_code(0) }
+      it { expect { described_class.new(args: ["-i"]).run }.to exit_with_code(0) }
+    end
+
+    context "when dotfile exists" do
+      before do
+        Swagcov::Command::GenerateDotfile.new(basename: dotfile_basename).run # create existing
+        File.truncate(dotfile_basename, 0)
+      end
+
+      after { FileUtils.rm_f(dotfile_basename) }
+
+      it "does not overwrite existing file" do
+        init.run
+      rescue SystemExit => _e
+        expect(File.read(dotfile_basename)).to eq("")
+      end
+
+      it "has message" do
+        expect { init.run }.to raise_exception(SystemExit).and output(
+          <<~MESSAGE
+            #{dotfile_basename} already exists at #{Swagcov.project_root}
+          MESSAGE
+        ).to_stdout
+      end
+
+      it { expect { init.run }.to exit_with_code(2) }
+      it { expect { described_class.new(args: ["-i"]).run }.to exit_with_code(2) }
+    end
+  end
+
+  context "with --todo" do
+    let(:args) { ["--todo"] }
+    let(:todo_basename) { ".swagcov_todo_test.yml" }
+    let(:dotfile_basename) { ".swagcov_test.yml" }
+
+    before do
+      stub_const("Swagcov::Dotfile::TODO_CONFIG_FILE_NAME", todo_basename)
+      stub_const("Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME", dotfile_basename)
+      Swagcov::Command::GenerateDotfile.new(basename: dotfile_basename).run
+    end
+
+    after do
+      [todo_basename, dotfile_basename].each { |basename| FileUtils.rm_f(basename) }
+    end
+
+    it "generates a todo configuration file" do
+      init.run
+    rescue SystemExit => _e
+      expect(File.read(todo_basename)).to eq(
+        <<~YAML
+          # This configuration was auto generated
+          # The intent is to remove these route configurations as documentation is added
+
+        YAML
+      )
+    end
+
+    it "prints message" do
+      expect { init.run }.to raise_exception(SystemExit).and output(
+        <<~MESSAGE
+          created #{todo_basename} at #{Swagcov.project_root}
+        MESSAGE
+      ).to_stdout
+    end
+
+    it { expect { init.run }.to exit_with_code(0) }
+    it { expect { described_class.new(args: ["-t"]).run }.to exit_with_code(0) }
+  end
+
+  context "with an invalid option" do
+    let(:args) { ["--foobar"] }
+
+    it "prints message" do
+      expect { init.run }.to raise_exception(SystemExit).and output(
+        <<~MESSAGE
+          invalid option: --foobar
+          For usage information, use --help
+        MESSAGE
+      ).to_stderr
+    end
+
+    it { expect { init.run }.to exit_with_code(2) }
+  end
+
+  context "without options and with minimum required configuration" do
+    let(:args) { [] }
+    let(:dotfile_basename) { ".swagcov_test.yml" }
+
+    before do
+      stub_const("Swagcov::Dotfile::DEFAULT_CONFIG_FILE_NAME", dotfile_basename)
+      Swagcov::Command::GenerateDotfile.new(basename: dotfile_basename).run # create for minimum required config
+    end
+
+    after { FileUtils.rm_f(dotfile_basename) }
+
+    # rubocop:disable Layout/EmptyLinesAroundArguments
+    it "prints coverage" do
+      expect { init.run }.to raise_exception(SystemExit).and output(
+        <<~MESSAGE
+
+          OpenAPI documentation coverage NaN% (0/0)
+          #{0.to_s.yellow} ignored endpoints
+          #{0.to_s.blue} total endpoints
+          #{0.to_s.green} covered endpoints
+          #{0.to_s.red} uncovered endpoints
+        MESSAGE
+      ).to_stdout
+    end
+    # rubocop:enable Layout/EmptyLinesAroundArguments
+
+    it { expect { init.run }.to exit_with_code(0) }
+  end
+
+  context "without options and without required configuration" do
+    let(:args) { [] }
+
+    it "prints message" do
+      expect { init.run }.to raise_exception(SystemExit).and output(
+        <<~MESSAGE
+          Swagcov::Errors::BadConfiguration: Missing config file (.swagcov.yml)
+        MESSAGE
+      ).to_stderr
+    end
+
+    it { expect { init.run }.to exit_with_code(2) }
+  end
+end

--- a/swagcov.gemspec
+++ b/swagcov.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["lib/**/*", "CHANGELOG.md", "LICENSE", "README.md"]
+  spec.bindir = "exe"
+  spec.executables = ["swagcov"]
 
   spec.required_ruby_version = ">= 2.5.0"
   spec.add_dependency "railties", ">= 4.2"


### PR DESCRIPTION
Created executable
- This is considered experimental due to the rails booting approach - it may not work for all use cases
- The following can now be ran:
  - `swagcov`
  - `swagcov --init`
  - `swagcov --todo`
    
Thoughts to deal with later:
- `system %(swagcov)` based tests are considerably slow - curious on a better cli testing option for true e2e tests
  