### PR TITLE
Replace swagcov:install with swagcov -- --init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 ## main (unreleased)
--
+- `BREAKING CHANGE`: `rake swagcov:install` is now `rake swagcov -- --init` ([#121](https://github.com/smridge/swagcov/pull/121))
 
 ## 0.9.0 (2025-05-07)
 ### Enhancement

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OpenAPI documentation coverage report for Rails Routes.
 **Generate required `.swagcov.yml` config file**
 | `executable    ` | `rake task                 ` | `rails console                             ` |
 | :---             | :---                         | :---                                         |
-| `swagcov --init` | `rake swagcov:install`       | `Swagcov::Command::GenerateDotfile.new.run`  |
+| `swagcov --init` | `rake swagcov -- --init`     | `Swagcov::Command::GenerateDotfile.new.run`  |
 
 
 **Generate optional `.swagcov_todo.yml` config file**

--- a/lib/swagcov/options.rb
+++ b/lib/swagcov/options.rb
@@ -12,7 +12,11 @@ module Swagcov
       options = {}
 
       ::OptionParser.new do |opts|
-        opts.banner = "Usage: swagcov [options]"
+        opts.banner = <<~MESSAGE
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
+        MESSAGE
 
         opts.on("-i", "--init", "Generate required .swagcov.yml config file") do |opt|
           options[:init] = opt

--- a/lib/tasks/swagcov.rake
+++ b/lib/tasks/swagcov.rake
@@ -2,5 +2,6 @@
 
 desc "Check OpenAPI documentation coverage for Rails Route endpoints"
 task swagcov: :environment do
-  exit Swagcov::Command::ReportCoverage.new.run
+  args = ARGV.drop(2) # Remove "swagcov" and "--" to ignore standard rake arguments
+  Swagcov::Runner.new(args: args).run
 end

--- a/lib/tasks/swagcov/install.rake
+++ b/lib/tasks/swagcov/install.rake
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-namespace :swagcov do
-  desc "Generate required .swagcov.yml config file"
-  task install: :environment do
-    exit Swagcov::Command::GenerateDotfile.new.run
-  end
-end

--- a/spec/sandbox_4_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_4_2/spec/exe/swagcov_spec.rb
@@ -93,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_5_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_5_0/spec/exe/swagcov_spec.rb
@@ -93,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_5_1/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_5_1/spec/exe/swagcov_spec.rb
@@ -93,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_5_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_5_2/spec/exe/swagcov_spec.rb
@@ -93,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_6_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_6_0/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end
@@ -91,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_6_1/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_6_1/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end
@@ -91,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_7_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_7_0/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end
@@ -91,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_7_1/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_7_1/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end
@@ -91,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_7_2/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_7_2/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end
@@ -91,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/sandbox_8_0/spec/exe/swagcov_spec.rb
+++ b/spec/sandbox_8_0/spec/exe/swagcov_spec.rb
@@ -77,9 +77,11 @@ describe "[executable] swagcov" do
 
       it "prints message" do
         expect { swagcov }.to output(
-          <<~MESSAGE
-            Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
-          MESSAGE
+          a_string_including(
+            <<~MESSAGE
+              Swagcov::Errors::BadConfiguration: Missing config file (spec/fixtures/dotfiles/no-dotfile.yml)
+            MESSAGE
+          )
         ).to_stderr_from_any_process
       end
     end
@@ -91,7 +93,9 @@ describe "[executable] swagcov" do
     it "prints options" do
       expect { swagcov }.to output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE

--- a/spec/swagcov/options_spec.rb
+++ b/spec/swagcov/options_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe Swagcov::Options do
       it "prints options" do
         expect { init.define }.to raise_exception(SystemExit).and output(
           <<~MESSAGE
-            Usage: swagcov [options]
+            Usage:
+            * as executable: swagcov [options]
+            * as rake task: rake swagcov -- [options]
                 -i, --init                       Generate required .swagcov.yml config file
                 -t, --todo                       Generate optional .swagcov_todo.yml config file
           MESSAGE
@@ -49,7 +51,9 @@ RSpec.describe Swagcov::Options do
       it "prints options" do
         expect { init.define }.to raise_exception(SystemExit).and output(
           <<~MESSAGE
-            Usage: swagcov [options]
+            Usage:
+            * as executable: swagcov [options]
+            * as rake task: rake swagcov -- [options]
                 -i, --init                       Generate required .swagcov.yml config file
                 -t, --todo                       Generate optional .swagcov_todo.yml config file
           MESSAGE

--- a/spec/swagcov/runner_spec.rb
+++ b/spec/swagcov/runner_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Swagcov::Runner do
     it "prints options" do
       expect { init.run }.to raise_exception(SystemExit).and output(
         <<~MESSAGE
-          Usage: swagcov [options]
+          Usage:
+          * as executable: swagcov [options]
+          * as rake task: rake swagcov -- [options]
               -i, --init                       Generate required .swagcov.yml config file
               -t, --todo                       Generate optional .swagcov_todo.yml config file
         MESSAGE


### PR DESCRIPTION
- This approach consolidates the options parser logic with the executable created in https://github.com/smridge/swagcov/pull/120
- Going forward, additional rake tasks do not need to manually added but rather can accept cli options